### PR TITLE
feat: Improve error handling and refactor code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.0.2-beta
+
+*   Enhances error handling within the NFC wallet suppression plugin and refactors the code for better clarity.
+*   **iOS:** Improved error handling for iOS.
+*   **Android:** Got a working implementation of the NFC wallet suppression plugin.
+
 ## 0.0.1
 
 *   Initial release of the `nfc_wallet_suppression` plugin.

--- a/android/src/main/kotlin/dev/teklund/nfc_wallet_suppression/NfcWalletSuppressionPlugin.kt
+++ b/android/src/main/kotlin/dev/teklund/nfc_wallet_suppression/NfcWalletSuppressionPlugin.kt
@@ -80,7 +80,7 @@ class NfcWalletSuppressionPlugin: FlutterPlugin, MethodCallHandler, ActivityAwar
     val activity = activity
     val nfcAdapter = NfcAdapter.getDefaultAdapter(activity)
     if (nfcAdapter == null || activity == null || !nfcAdapter.isEnabled() ) {
-      result.error("404", "NFC not available", null)
+      result.error("UNAVAILABLE", "NFC not available", null)
       return
     }
 
@@ -111,7 +111,7 @@ class NfcWalletSuppressionPlugin: FlutterPlugin, MethodCallHandler, ActivityAwar
   private fun releaseSuppression(result: Result) {
     val nfcAdapter = NfcAdapter.getDefaultAdapter(activity)
     if (nfcAdapter == null || activity == null || !nfcAdapter.isEnabled() ) {
-      result.error("404", "NFC not available", null)
+      result.error("UNAVAILABLE", "NFC not available", null)
       return
     }
     nfcAdapter.disableForegroundDispatch(activity)

--- a/example/integration_test/plugin_integration_test.dart
+++ b/example/integration_test/plugin_integration_test.dart
@@ -15,7 +15,7 @@ void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
 
   testWidgets('isSuppressed test', (WidgetTester tester) async {
-    final bool? suppressed = await NfcWalletSuppression.isSuppressed();
+    final bool suppressed = await NfcWalletSuppression.isSuppressed();
     // The version string depends on the host platform running the test, so
     // just assert that some non-empty string is returned.
     expect(suppressed, true);

--- a/ios/Classes/NfcWalletSuppressionPlugin.swift
+++ b/ios/Classes/NfcWalletSuppressionPlugin.swift
@@ -32,39 +32,52 @@ public class NfcWalletSuppressionPlugin: NSObject, FlutterPlugin {
 //              return
 //          }
     //https://developer.apple.com/documentation/passkit/pkpasslibrary/requestautomaticpasspresentationsuppression(responsehandler:)
-    suppressionToken = PKPassLibrary.requestAutomaticPassPresentationSuppression(responseHandler: { result in
+    self.suppressionToken = PKPassLibrary.requestAutomaticPassPresentationSuppression(responseHandler: { requestResult in
       //https://developer.apple.com/documentation/passkit/pkautomaticpasspresentationsuppressionresult
-      switch result {
+      switch requestResult {
         case .success:
           print("Pass presentation suppressed successfully.")
-//        case .alreadySuppressed:
-//          print("Pass presentation was already suppressed.")
+            result("Suppressed")
+        case .notSupported:
+            result(FlutterError(code: "NOT_SUPPORTED",
+                message: "The device doesn’t support the suppression of automatic pass presentation.",
+                details: nil))
+        case .alreadyPresenting:
+            result(FlutterError(code: "ALREADY_PRESENTING",
+                message: "The device is already presenting passes.",
+                details: nil))
+        case .cancelled:
+            result(FlutterError(code: "CANCELLED",
+                message: "Suppression cancelled",
+                details: nil))
         case .denied:
-          print("Pass presentation suppression denied.")
-//        case .failed:
-//          print("Pass presentation suppression failed.")
+            result(FlutterError(code: "DENIED",
+                message: "The user prevented the suppression, or an internal error occurred.",
+                details: nil))
         @unknown default:
-          print("Unknown suppression result.")
+          result(FlutterError(code: "UNKNOWN",
+                message: "Unknown suppression result.",
+                details: nil))
         }
     })
-    print("Automatic Pass Presentation Suppressed")
 //    guard let suppressionToken = token else {
 //      result(false)
 //      return
 //    }
-    result(true)
   }
 
   //https://developer.apple.com/documentation/passkit/pkpasslibrary/endautomaticpasspresentationsuppression(withrequesttoken:)
   private func releaseSuppression(result: @escaping FlutterResult) {
     guard let token = suppressionToken else {
-      result(false)
+      result(FlutterError(code: "UNAVAILABLE",
+                                     message: "NFC not available",
+                                     details: nil))
       return
     }
     PKPassLibrary.endAutomaticPassPresentationSuppression(withRequestToken: token)
     print("Automatic Pass Presentation enabled")
     suppressionToken = nil
-    result(true)
+    result("Not suppressed anymore")
   }
 
   private func isSuppressed(result: @escaping FlutterResult) {

--- a/lib/nfc_wallet_suppression.dart
+++ b/lib/nfc_wallet_suppression.dart
@@ -1,30 +1,6 @@
-import 'nfc_wallet_suppression_platform_interface.dart';
+library;
 
-/// Provides a mechanism to suppress the system's NFC wallet behavior.
-///
-/// This class allows you to temporarily prevent the system from showing its NFC
-/// wallet UI when an NFC tag is detected.
-class NfcWalletSuppression {
-  /// Requests suppression of the system's NFC wallet behavior.
-  ///
-  /// Returns `true` if suppression was successfully requested, `false` if
-  /// suppression could not be requested, and `null` if the platform does not
-  /// support suppression.
-  static Future<bool?> requestSuppression() {
-    return NfcWalletSuppressionPlatform.instance.requestSuppression();
-  }
-
-  /// Releases suppression of the system's NFC wallet behavior.
-  ///
-  /// Returns `true` if suppression was successfully released, `false` if
-  /// suppression could not be released, and `null` if the platform does not
-  /// support suppression.
-  static Future<bool?> releaseSuppression() {
-    return NfcWalletSuppressionPlatform.instance.releaseSuppression();
-  }
-
-  /// Checks if the system's NFC wallet behavior is currently suppressed.
-  static Future<bool?> isSuppressed() {
-    return NfcWalletSuppressionPlatform.instance.isSuppressed();
-  }
-}
+export 'src/nfc_wallet_suppression.dart';
+export 'src/nfc_wallet_suppression_status.dart';
+export 'src/nfc_wallet_suppression_method_channel.dart';
+export 'src/nfc_wallet_suppression_platform_interface.dart';

--- a/lib/src/nfc_wallet_suppression.dart
+++ b/lib/src/nfc_wallet_suppression.dart
@@ -1,0 +1,31 @@
+import 'nfc_wallet_suppression_platform_interface.dart';
+import 'nfc_wallet_suppression_status.dart';
+
+/// Provides a mechanism to suppress the system's NFC wallet behavior.
+///
+/// This class allows you to temporarily prevent the system from showing its NFC
+/// wallet UI when an NFC tag is detected.
+class NfcWalletSuppression {
+  /// Requests suppression of the system's NFC wallet behavior.
+  ///
+  /// Returns `true` if suppression was successfully requested, `false` if
+  /// suppression could not be requested, and `null` if the platform does not
+  /// support suppression.
+  static Future<SuppressionStatus> requestSuppression() {
+    return NfcWalletSuppressionPlatform.instance.requestSuppression();
+  }
+
+  /// Releases suppression of the system's NFC wallet behavior.
+  ///
+  /// Returns `true` if suppression was successfully released, `false` if
+  /// suppression could not be released, and `null` if the platform does not
+  /// support suppression.
+  static Future<SuppressionStatus> releaseSuppression() {
+    return NfcWalletSuppressionPlatform.instance.releaseSuppression();
+  }
+
+  /// Checks if the system's NFC wallet behavior is currently suppressed.
+  static Future<bool> isSuppressed() {
+    return NfcWalletSuppressionPlatform.instance.isSuppressed();
+  }
+}

--- a/lib/src/nfc_wallet_suppression_method_channel.dart
+++ b/lib/src/nfc_wallet_suppression_method_channel.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 
+import 'nfc_wallet_suppression_status.dart';
 import 'nfc_wallet_suppression_platform_interface.dart';
 
 /// An implementation of [NfcWalletSuppressionPlatform] that uses method channels.
@@ -13,7 +14,7 @@ class MethodChannelNfcWalletSuppression extends NfcWalletSuppressionPlatform {
   ///
   /// Returns `true` if the suppression was successfully requested, `false` otherwise.
   @override
-  Future<bool?> requestSuppression() async {
+  Future<SuppressionStatus> requestSuppression() async {
     try {
       final msg = await methodChannel.invokeMethod<String?>(
         'requestSuppression',
@@ -24,24 +25,20 @@ class MethodChannelNfcWalletSuppression extends NfcWalletSuppressionPlatform {
           print(msg);
         }
       }
+      return SuppressionStatus.suppressed;
     } on PlatformException catch (e) {
       if (kDebugMode) {
         print(e.message ?? "No error message supplied");
       }
-
-      if (e.code == "404") return null;
-
-      return false;
+      return _suppressionStatus(e.code);
     }
-
-    return true;
   }
 
   /// Releases the suppression of the NFC wallet.
   ///
   /// Returns `true` if the suppression was successfully released, `false` otherwise.
   @override
-  Future<bool?> releaseSuppression() async {
+  Future<SuppressionStatus> releaseSuppression() async {
     try {
       final msg = await methodChannel.invokeMethod<String>(
         'releaseSuppression',
@@ -52,24 +49,42 @@ class MethodChannelNfcWalletSuppression extends NfcWalletSuppressionPlatform {
           print(msg);
         }
       }
+      return SuppressionStatus.notSuppressed;
     } on PlatformException catch (e) {
       if (kDebugMode) {
         print(e.message ?? "No error message supplied");
       }
-
-      if (e.code == "404") return null;
-
-      return false;
+      return _suppressionStatus(e.code);
     }
-    return true;
+  }
+
+  SuppressionStatus _suppressionStatus(String code) {
+    switch (code) {
+      case "NOT_SUPPORTED":
+        return SuppressionStatus.notSupported;
+      case "ALREADY_PRESENTING":
+        return SuppressionStatus.alreadyPresenting;
+      case "CANCELLED":
+        return SuppressionStatus.cancelled;
+      case "DENIED":
+        return SuppressionStatus.denied;
+      case "UNAVAILABLE":
+        return SuppressionStatus.unavailable;
+      case "UNKNOWN":
+      default:
+        if (kDebugMode) {
+          print("Unknown code: $code");
+        }
+        return SuppressionStatus.unknown;
+    }
   }
 
   /// Checks if the NFC wallet is currently suppressed.
   ///
   /// Returns `true` if the wallet is suppressed, `false` otherwise.
   @override
-  Future<bool?> isSuppressed() async {
+  Future<bool> isSuppressed() async {
     final success = await methodChannel.invokeMethod<bool>('isSuppressed');
-    return success;
+    return success ?? false;
   }
 }

--- a/lib/src/nfc_wallet_suppression_platform_interface.dart
+++ b/lib/src/nfc_wallet_suppression_platform_interface.dart
@@ -1,6 +1,7 @@
 import 'package:plugin_platform_interface/plugin_platform_interface.dart';
 
 import 'nfc_wallet_suppression_method_channel.dart';
+import 'nfc_wallet_suppression_status.dart';
 
 /// An interface for a platform-specific implementation of the `nfc_wallet_suppression` plugin.
 ///
@@ -33,7 +34,7 @@ abstract class NfcWalletSuppressionPlatform extends PlatformInterface {
   ///
   /// Returns `true` if the request was successful, `false` if it failed, and `null`
   /// if the platform does not support this method.
-  Future<bool?> requestSuppression() {
+  Future<SuppressionStatus> requestSuppression() {
     throw UnimplementedError('requestSuppression() has not been implemented.');
   }
 
@@ -41,7 +42,7 @@ abstract class NfcWalletSuppressionPlatform extends PlatformInterface {
   ///
   /// Returns `true` if the release was successful, `false` if it failed, and `null`
   /// if the platform does not support this method.
-  Future<bool?> releaseSuppression() {
+  Future<SuppressionStatus> releaseSuppression() {
     throw UnimplementedError('releaseSuppression() has not been implemented.');
   }
 
@@ -49,7 +50,7 @@ abstract class NfcWalletSuppressionPlatform extends PlatformInterface {
   ///
   /// Returns `true` if the wallet is suppressed, `false` if it is not, and `null`
   /// if the platform does not support this method.
-  Future<bool?> isSuppressed() {
+  Future<bool> isSuppressed() {
     throw UnimplementedError('isSuppressed() has not been implemented.');
   }
 }

--- a/lib/src/nfc_wallet_suppression_status.dart
+++ b/lib/src/nfc_wallet_suppression_status.dart
@@ -1,0 +1,38 @@
+/// Enum representing the status of suppression for NFC wallet interaction.
+///
+/// - `notSuppressed`: The NFC wallet interaction is not suppressed.
+/// - `suppressed`: The NFC wallet interaction is suppressed.
+/// - `unavailable`: The NFC wallet interaction suppression is unavailable.
+/// - `denied`: The NFC wallet interaction suppression was denied.
+/// - `cancelled`: The NFC wallet interaction suppression was cancelled.
+/// - `notSupported`: The NFC wallet interaction suppression is not supported.
+/// - `alreadyPresenting`: The NFC wallet interaction is already presenting.
+/// - `unknown`: The NFC wallet interaction suppression status is unknown.
+///
+/// This enum provides a structured way to represent different states
+/// related to the suppression of NFC wallet interactions.
+enum SuppressionStatus {
+  /// `notSuppressed`: The NFC wallet interaction is not suppressed.
+  notSuppressed,
+
+  /// `suppressed`: The NFC wallet interaction is suppressed.
+  suppressed,
+
+  /// `unavailable`: The NFC wallet interaction suppression is unavailable.
+  unavailable,
+
+  /// `denied`: The NFC wallet interaction suppression was denied.
+  denied,
+
+  /// `cancelled`: The NFC wallet interaction suppression was cancelled.
+  cancelled,
+
+  /// `notSupported`: The NFC wallet interaction suppression is not supported.
+  notSupported,
+
+  /// `alreadyPresenting`: The NFC wallet interaction is already presenting.
+  alreadyPresenting,
+
+  /// `unknown`: The NFC wallet interaction suppression status is unknown.
+  unknown,
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: nfc_wallet_suppression
 description: "Lightweight plugin to handle NFC wallet suppression in Flutter"
-version: 0.0.1-beta
+version: 0.0.2-beta
 homepage: https://github.com/teklund/nfc_wallet_suppression
 
 environment:

--- a/test/nfc_wallet_suppression_method_channel_test.dart
+++ b/test/nfc_wallet_suppression_method_channel_test.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:nfc_wallet_suppression/nfc_wallet_suppression_method_channel.dart';
+import 'package:nfc_wallet_suppression/nfc_wallet_suppression.dart';
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();

--- a/test/nfc_wallet_suppression_test.dart
+++ b/test/nfc_wallet_suppression_test.dart
@@ -1,7 +1,5 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:nfc_wallet_suppression/nfc_wallet_suppression.dart';
-import 'package:nfc_wallet_suppression/nfc_wallet_suppression_method_channel.dart';
-import 'package:nfc_wallet_suppression/nfc_wallet_suppression_platform_interface.dart';
 import 'package:plugin_platform_interface/plugin_platform_interface.dart';
 
 class MockNfcWalletSuppressionPlatform
@@ -10,15 +8,15 @@ class MockNfcWalletSuppressionPlatform
   bool _isSuppressing = false;
 
   @override
-  Future<bool?> requestSuppression() {
+  Future<SuppressionStatus> requestSuppression() {
     _isSuppressing = true;
-    return Future.value(true);
+    return Future.value(SuppressionStatus.suppressed);
   }
 
   @override
-  Future<bool?> releaseSuppression() {
+  Future<SuppressionStatus> releaseSuppression() {
     _isSuppressing = false;
-    return Future.value(true);
+    return Future.value(SuppressionStatus.notSuppressed);
   }
 
   @override


### PR DESCRIPTION
This commit enhances error handling within the NFC wallet suppression plugin and refactors the code for better clarity.

-   Introduces `SuppressionStatus` enum to represent various states of NFC wallet suppression.
-   Updates `requestSuppression` and `releaseSuppression` methods to return `SuppressionStatus` instead of `bool?`.
-   Refactors method channel handling to use `SuppressionStatus` for platform error responses.
-   Updates Android and iOS implementations to handle different error conditions and return corresponding `SuppressionStatus`.
-   Refactors mock implementations in tests to align with new `SuppressionStatus` and improved error handling.
-   Updates the example application to showcase new features and error handling.
-   Removes `nfc_wallet_suppression_method_channel_test.dart` test file.
-   Moves files to src directory.