### PR TITLE
feat: Make NFC permission optional on Android and bump version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
-## 0.1.0
+## 0.1.1
+
+* **FIX** Don't require nfc permission on Android
 
 * First stable release of the `nfc_wallet_suppression` plugin.
 * **DOCS** Updated readme

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ in the plugins AndroidManifest.xml file.
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <!-- You need to add following permissions to your AndroidManifest.xml file -->
     <uses-permission android:name="android.permission.NFC" />
-    <uses-feature android:name="android.hardware.nfc" android:required="true" />
+    <uses-feature android:name="android.hardware.nfc" android:required="false" />
 </manifest>
 ```
 

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,5 +1,5 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
   package="dev.teklund.nfc_wallet_suppression">
     <uses-permission android:name="android.permission.NFC" />
-    <uses-feature android:name="android.hardware.nfc" android:required="true" />
+    <uses-feature android:name="android.hardware.nfc" android:required="false" />
 </manifest>

--- a/example/android/app/src/main/AndroidManifest.xml
+++ b/example/android/app/src/main/AndroidManifest.xml
@@ -1,7 +1,4 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
-    <uses-permission android:name="android.permission.NFC" />
-    <uses-feature android:name="android.hardware.nfc" android:required="true" />
-
     <application
         android:label="nfc_wallet_suppression_example"
         android:name="${applicationName}"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: nfc_wallet_suppression
 description: "Lightweight plugin to handle NFC wallet suppression in Flutter"
-version: 0.1.0
+version: 0.1.1
 homepage: https://github.com/teklund/nfc_wallet_suppression
 
 environment:


### PR DESCRIPTION
feat: Make NFC permission optional on Android and bump version
- Updates the Android `AndroidManifest.xml` to make the NFC hardware feature not required.
- Updates the `pubspec.yaml` version to 0.1.1.
- Updates the `CHANGELOG.md` to reflect the change.