### PR TITLE
fix(android): make plugin Flutter 3.44-ready via conditional Built-in Kotlin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to this project will be documented in this file.
 
+## Unreleased
+
+### Changed
+
+- 🤖 **Android Built-in Kotlin migration (Flutter 3.44+)**: The Android build no
+  longer unconditionally applies the Kotlin Gradle Plugin. From AGP 9 onward Kotlin
+  is provided by AGP itself; KGP is now applied conditionally (only for AGP < 9) so
+  the plugin keeps building on both new and older toolchains. The deprecated
+  `kotlinOptions` block was replaced with the modern `kotlin.compilerOptions` DSL.
+  No change to the supported Flutter range — the plugin still targets Flutter 3.35.0+.
+- ⬆️ **Example toolchain bump**: Example app updated to Gradle 8.14, Android Gradle
+  Plugin 8.11.1, and Kotlin 2.2.20 to track currently-supported build tooling.
+
 ## 1.0.0
 
 Major release with Pigeon migration for type-safe platform channels.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ All notable changes to this project will be documented in this file.
   No change to the supported Flutter range — the plugin still targets Flutter 3.35.0+.
 - ⬆️ **Example toolchain bump**: Example app updated to Gradle 8.14, Android Gradle
   Plugin 8.11.1, and Kotlin 2.2.20 to track currently-supported build tooling.
+- 🧪 **JaCoCo coverage config**: Dropped the deprecated `testCoverageEnabled` build
+  flag (incompatible with AGP 8.11+ Gradle task validation); unit-test coverage now
+  relies solely on the Gradle JaCoCo extension already configured in `testOptions`.
 
 ## 1.0.0
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -77,11 +77,6 @@ android {
         }
     }
     
-    buildTypes {
-        debug {
-            testCoverageEnabled = true
-        }
-    }
 }
 
 // Built-in Kotlin: configure the JVM target via the modern compilerOptions DSL

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -2,7 +2,7 @@ group = "dev.teklund.nfc_wallet_suppression"
 version = "1.0-SNAPSHOT"
 
 buildscript {
-    ext.kotlin_version = "1.9.22"
+    ext.kotlin_version = "2.2.20"
     repositories {
         google()
         mavenCentral()
@@ -22,8 +22,17 @@ allprojects {
 }
 
 apply plugin: "com.android.library"
-apply plugin: "kotlin-android"
 apply plugin: "jacoco"
+
+// Built-in Kotlin migration (Flutter 3.44+): from AGP 9 onward Kotlin support is
+// provided by AGP itself, so applying the Kotlin Gradle Plugin here would fail the
+// build. For older AGP (Flutter < 3.44) we keep applying KGP so the plugin still
+// builds for consumers on those toolchains.
+// See https://docs.flutter.dev/release/breaking-changes/migrate-to-built-in-kotlin/for-plugin-authors
+def agpMajor = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION.tokenize('.')[0] as int
+if (agpMajor < 9) {
+    apply plugin: "kotlin-android"
+}
 
 android {
     namespace = "dev.teklund.nfc_wallet_suppression"
@@ -33,10 +42,6 @@ android {
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_11
         targetCompatibility = JavaVersion.VERSION_11
-    }
-
-    kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_11.toString()
     }
 
     sourceSets {
@@ -76,6 +81,15 @@ android {
         debug {
             testCoverageEnabled = true
         }
+    }
+}
+
+// Built-in Kotlin: configure the JVM target via the modern compilerOptions DSL
+// (replaces the deprecated android.kotlinOptions block). Works whether KGP is
+// applied (older AGP) or provided by AGP (Built-in Kotlin, AGP 9+).
+kotlin {
+    compilerOptions {
+        jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_11
     }
 }
 

--- a/example/android/app/build.gradle.kts
+++ b/example/android/app/build.gradle.kts
@@ -13,6 +13,9 @@ java {
 
 kotlin {
     jvmToolchain(17)
+    compilerOptions {
+        jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17
+    }
 }
 
 android {
@@ -23,10 +26,6 @@ android {
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_17
         targetCompatibility = JavaVersion.VERSION_17
-    }
-
-    kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_17.toString()
     }
 
     defaultConfig {

--- a/example/android/gradle.properties
+++ b/example/android/gradle.properties
@@ -1,3 +1,7 @@
 org.gradle.jvmargs=-Xmx8G -XX:MaxMetaspaceSize=4G -XX:ReservedCodeCacheSize=512m -XX:+HeapDumpOnOutOfMemoryError
 android.useAndroidX=true
 android.enableJetifier=true
+# This builtInKotlin flag was added automatically by Flutter migrator
+android.builtInKotlin=false
+# This newDsl flag was added automatically by Flutter migrator
+android.newDsl=false

--- a/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14-all.zip

--- a/example/android/settings.gradle.kts
+++ b/example/android/settings.gradle.kts
@@ -19,8 +19,8 @@ pluginManagement {
 plugins {
     id("org.gradle.toolchains.foojay-resolver-convention") version "1.0.0"
     id("dev.flutter.flutter-plugin-loader") version "1.0.0"
-    id("com.android.application") version "8.7.0" apply false
-    id("org.jetbrains.kotlin.android") version "1.9.22" apply false
+    id("com.android.application") version "8.11.1" apply false
+    id("org.jetbrains.kotlin.android") version "2.2.20" apply false
 }
 
 include(":app")


### PR DESCRIPTION
## Summary

Makes the plugin forward-compatible with **Flutter 3.44** without dropping any current users. Flutter 3.44 deprecates plugins that apply the Kotlin Gradle Plugin (KGP); future Flutter / AGP 9 releases will *fail to build* apps that depend on such plugins. This migrates the Android build to **Built-in Kotlin** using the conditional pattern from the [official plugin-author guide](https://docs.flutter.dev/release/breaking-changes/migrate-to-built-in-kotlin/for-plugin-authors), so the plugin builds cleanly on both new and old toolchains.

> Note: the plugin already *builds and runs* on 3.44 today — these were deprecation warnings, not errors. This change is future-proofing ahead of the AGP 9 / KGP-removal hard break.

## Changes

**Plugin (`android/build.gradle`)**
- Apply `kotlin-android` **only when AGP < 9** (from AGP 9, Kotlin is provided by AGP itself — applying KGP would break the build).
- Replace the deprecated `android.kotlinOptions` block with the modern `kotlin.compilerOptions` DSL.
- Bump plugin KGP to `2.2.20` (required for the `compilerOptions` DSL).
- Drop the deprecated `buildTypes.debug.testCoverageEnabled` flag — it's incompatible with AGP 8.11's stricter Gradle task-node validation (`jacocoCoverageOutputFile` error). Unit-test coverage already comes from the Gradle JaCoCo extension in `testOptions.unitTests.all { jacoco {} }`.

**Example app (not part of the published contract)**
- Gradle `8.10.2 → 8.14`, AGP `8.7.0 → 8.11.1`, Kotlin `1.9.22 → 2.2.20` — clears the "support will soon be dropped" warnings.
- Migrate the example's `kotlinOptions` → `compilerOptions` to avoid a new Kotlin 2.x deprecation.
- Commit the Flutter migrator's `gradle.properties` shim (`builtInKotlin=false`, `newDsl=false`).

## Compatibility

✅ **No change to the supported Flutter range** — still `flutter: ">=3.35.0"` / `sdk: ^3.9.0`. This is **not** a breaking change; no SemVer bump required. (A full migration that raises the floor to 3.44 was intentionally avoided.)

## Why stay on AGP 8.11.1 (not AGP 9)

AGP 9 has shipped (9.0.1 Jan 2026, 9.2.0 Apr 2026), but **Flutter 3.44's own Gradle plugin is not yet AGP-9-ready**. Building the example against AGP 9.0.1 / Gradle 9.1.0 fails *upstream* — `dev.flutter.flutter-gradle-plugin` throws a `NullPointerException` because `flutter_tools` still uses AGP variant APIs (`ApkVariant`, `BaseVariantOutput`) removed in AGP 9. Tracked in flutter/flutter [#175688](https://github.com/flutter/flutter/issues/175688) and [#181383](https://github.com/flutter/flutter/issues/181383). So the example stays on AGP 8.11.1 (Flutter 3.44's template default), and the conditional `agpMajor < 9` guard prepares the plugin for AGP 9 once Flutter's support lands.

## Remaining advisory warnings (expected, not regressions)

- *"plugin nfc_wallet_suppression applies KGP"* — **intentional** on AGP 8: the conditional guard still applies KGP for AGP < 9 because Kotlin must be compiled on those toolchains. The guard skips it from AGP 9 onward.
- *"example app applies KGP"* — the example app's own Built-in Kotlin migration; deliberately out of scope here since it doesn't affect the published plugin.

## Testing

Verified on a physical **Pixel 5 (Android 14, API 34)** with Flutter 3.44.0 / Dart 3.12.0:
- `flutter analyze` — clean · `flutter test` — 84/84 passing
- `flutter build apk --debug` — succeeds; the 3 toolchain-version warnings are gone
- Android native tests + JaCoCo coverage (`:nfc_wallet_suppression:testDebugUnitTest :jacocoTestReport`) — pass, coverage XML generated
- App installs, launches, plugin reports `isSupported=true (NFC adapter: present)` at runtime
- **AGP 9 investigation**: confirmed the AGP-9 build break is upstream in Flutter (see above), not in this plugin's code; the `agpMajor < 9` branch follows the official plugin-author guide and is not runtime-testable via Flutter until Flutter's AGP 9 support ships.
- Full CI matrix green on both Flutter 3.35.x and stable (3.44).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
