### PR TITLE
fix(ci): repair iOS Native Tests job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -306,10 +306,13 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-pods-
       
-      - name: Install CocoaPods dependencies
-        working-directory: example/ios
-        run: pod install
-      
+      - name: Build example for simulator
+        working-directory: example
+        # Drives pod install, generates the plugin registrant, and compiles the
+        # plugin pods (e.g. integration_test) so the Runner target builds before
+        # `xcodebuild test`. A bare `pod install` leaves the module unbuilt.
+        run: flutter build ios --debug --simulator --no-codesign
+
       - name: Install xcpretty (for better output)
         run: gem install xcpretty
       
@@ -352,7 +355,7 @@ jobs:
         working-directory: example/ios
         run: |
           set -o pipefail
-          rm -rf TestResults.xcresult || true
+          rm -rf TestResults.xcresult
           xcodebuild test \
             -workspace Runner.xcworkspace \
             -scheme Runner \
@@ -360,13 +363,7 @@ jobs:
             -only-testing:RunnerTests \
             -enableCodeCoverage YES \
             -resultBundlePath TestResults.xcresult \
-            | xcpretty --color --simple || xcodebuild test \
-            -workspace Runner.xcworkspace \
-            -scheme Runner \
-            -destination 'platform=iOS Simulator,id=${{ steps.simulator.outputs.udid }}' \
-            -only-testing:RunnerTests \
-            -enableCodeCoverage YES \
-            -resultBundlePath TestResults.xcresult
+            | xcpretty --color --simple
       
       - name: Convert iOS coverage to lcov
         if: always()


### PR DESCRIPTION
## Problem

The **iOS Native Tests** job has been failing on every PR that triggers it (e.g. #13, #33) with:

```
Module 'integration_test' not found
Testing cancelled because the build failed.
xcodebuild: error: Existing file at -resultBundlePath ...TestResults.xcresult
```

This is a CI infrastructure bug, unrelated to the dependabot PRs it was blocking.

## Root causes & fixes

1. **`integration_test` module not found** — the job ran a bare `pod install` then `xcodebuild test`, so the `integration_test` plugin (a Flutter-SDK dev dependency that the generated plugin registrant `@import`s) was never compiled and the `Runner` target failed to build. Replaced with `flutter build ios --debug --simulator --no-codesign`, which drives pod install, regenerates the registrant, and compiles the plugin pods — the same path the passing **Build iOS** job uses.

2. **`Existing file at -resultBundlePath` (exit 64)** — the test step's `|| xcodebuild …` retry reused the same `-resultBundlePath` without cleaning it, so the fallback always died. Removed the fragile retry; `set -o pipefail` already propagates xcodebuild's exit code through `xcpretty`.

## Verification

Note: the `check_changes` iOS path filter does not include workflow files, so the iOS Native Tests job is **skipped on this PR itself**. It was verified locally instead, and will run in CI once #13/#33 are rebased onto master after this merges.

Verified locally on macOS (Xcode 26.5, Flutter 3.44.2, iPhone 17 Pro simulator) by running the exact fixed sequence:

- `flutter build ios --debug --simulator --no-codesign` → built cleanly, `integration_test` resolved.
- `xcodebuild test -only-testing:RunnerTests -resultBundlePath TestResults.xcresult` → `** TEST SUCCEEDED **`, all 3 RunnerTests passed, no exit-64 collision.