### PR TITLE
fix: rebuild native suppression lifecycle (iOS + Android) and harden CI gating

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,20 +1,13 @@
 name: CI
 
 on:
+  # No paths-ignore: the workflow must always run so the required "CI Success"
+  # gate always reports (a path-skipped workflow would leave PRs stuck waiting).
+  # Slow native/build jobs still skip per-job via the check_changes path filter.
   pull_request:
     branches: [ main, master ]
-    paths-ignore:
-      - '**.md'
-      - 'docs/**'
-      - 'LICENSE'
-      - '.gitignore'
   push:
     branches: [ main, master ]
-    paths-ignore:
-      - '**.md'
-      - 'docs/**'
-      - 'LICENSE'
-      - '.gitignore'
   workflow_dispatch:
 
 concurrency:
@@ -98,7 +91,7 @@ jobs:
     timeout-minutes: 10
     needs: format
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         flutter-version: ['3.35.x', 'stable']
     
@@ -427,21 +420,23 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     needs: analyze
-    if: github.event_name == 'pull_request'
-    
+    # Run on PRs and on pushes to the default branch so publishability is
+    # validated even when changes land without a PR.
+    if: github.event_name == 'pull_request' || github.event_name == 'push'
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
-      
+
       - name: Setup Flutter
         uses: subosito/flutter-action@v2
         with:
           channel: stable
           cache: true
-      
+
       - name: Install dependencies
         run: flutter pub get
-      
+
       - name: Validate package
         run: |
           flutter pub publish --dry-run 2>&1 | tee publish-output.txt
@@ -460,7 +455,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     needs: analyze
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request' || github.event_name == 'push'
     
     steps:
       - name: Checkout code
@@ -594,3 +589,36 @@ jobs:
           name: ios-build
           path: example/build/ios/iphoneos/Runner.app
           retention-days: 7
+
+  ci-success:
+    name: CI Success
+    runs-on: ubuntu-latest
+    # The single required status check. It depends on every other job and fails
+    # if any of them failed or was cancelled, while treating skipped jobs (e.g.
+    # path-filtered native/build jobs) as acceptable. Making this the only
+    # required check in branch protection keeps the ruleset stable across matrix
+    # and job changes.
+    if: always()
+    needs:
+      - check_changes
+      - format
+      - analyze
+      - test
+      - native-tests-android
+      - native-tests-ios
+      - publish-dry-run
+      - pana
+      - dependency-review
+      - build-android
+      - build-ios
+    steps:
+      - name: Verify all jobs succeeded
+        run: |
+          echo "Dependency results: ${{ join(needs.*.result, ', ') }}"
+          for result in ${{ join(needs.*.result, ' ') }}; do
+            if [ "$result" = "failure" ] || [ "$result" = "cancelled" ]; then
+              echo "::error::A required job did not succeed (result: $result)."
+              exit 1
+            fi
+          done
+          echo "All jobs succeeded or were skipped."

--- a/README.md
+++ b/README.md
@@ -154,14 +154,14 @@ The `SuppressionStatus` enum represents the result of suppression operations:
 
 | Status | Description |
 | :--- | :--- |
-| `suppressed` | Suppression is successfully active |
-| `notSuppressed` | Suppression is not active |
-| `unavailable` | Suppression feature is unavailable on this device |
-| `denied` | Suppression request was denied (missing entitlements or permissions) |
-| `cancelled` | Suppression was cancelled by the system |
-| `notSupported` | The platform doesn't support this feature |
-| `alreadyPresenting` | Wallet is already presenting (iOS-specific) |
-| `unknown` | Status could not be determined |
+| `suppressed` | Suppression is active |
+| `notSuppressed` | Suppression is not active (e.g. successfully released) |
+| `unavailable` | No active suppression to release; or, during `requestSuppression` on Android, NFC is turned off or no activity is attached (recoverable) |
+| `denied` | Permission denied — iOS: by the user or system; Android: a `SecurityException` on the NFC call |
+| `cancelled` | User cancelled the permission prompt (iOS only) |
+| `notSupported` | Suppression isn't supported — Android: no NFC hardware; iOS: PassKit reports it unsupported |
+| `alreadyPresenting` | Wallet is already presenting a pass (iOS only) |
+| `unknown` | An unexpected error occurred |
 
 **Important Notes:**
 

--- a/android/src/main/kotlin/dev/teklund/nfc_wallet_suppression/NfcWalletSuppressionPlugin.kt
+++ b/android/src/main/kotlin/dev/teklund/nfc_wallet_suppression/NfcWalletSuppressionPlugin.kt
@@ -18,14 +18,14 @@ import io.flutter.embedding.engine.plugins.activity.ActivityPluginBinding
  * this interface lets the plugin be driven by a fake in tests while using the
  * real adapter in production.
  */
-interface WalletSuppressor {
+internal interface WalletSuppressor {
   fun hasNfcHardware(context: Context): Boolean
   fun isNfcEnabled(context: Context): Boolean
 
   /**
    * Enables reader mode for [activity]. Reader mode takes over the NFC stack,
    * which suppresses wallet / host-card-emulation apps. Throws if it cannot be
-   * enabled (e.g. no adapter, security restriction).
+   * enabled (e.g., no adapter, or a security restriction).
    */
   fun startReaderMode(activity: Activity, callback: NfcAdapter.ReaderCallback)
 
@@ -43,9 +43,10 @@ internal class SystemWalletSuppressor : WalletSuppressor {
   override fun startReaderMode(activity: Activity, callback: NfcAdapter.ReaderCallback) {
     val adapter = NfcAdapter.getDefaultAdapter(activity)
       ?: throw IllegalStateException("No NFC adapter available")
-    // Reader mode alone suppresses wallet/HCE; foreground dispatch is neither
-    // needed nor compatible. We do not read tags, so skip the NDEF check, and
-    // suppress the platform discovery sound for our silent reader session.
+    // Reader mode alone suppresses wallet / host-card-emulation apps; foreground
+    // dispatch is neither needed nor compatible. We do not read tags, so we skip
+    // the NDEF check and suppress the platform discovery sound for our silent
+    // reader session.
     val flags = NfcAdapter.FLAG_READER_NFC_A or
       NfcAdapter.FLAG_READER_NFC_B or
       NfcAdapter.FLAG_READER_NFC_F or
@@ -85,7 +86,7 @@ class NfcWalletSuppressionPlugin internal constructor(
   override fun onAttachedToEngine(flutterPluginBinding: FlutterPlugin.FlutterPluginBinding) {
     NfcWalletSuppressionApi.setUp(flutterPluginBinding.binaryMessenger, this)
     context = flutterPluginBinding.applicationContext
-    // Set automatically by the build system (debug vs release); mirrors iOS #if DEBUG.
+    // Set automatically by the build system (debug vs. release); mirrors iOS's #if DEBUG.
     isDebug = ((context?.applicationInfo?.flags ?: 0) and ApplicationInfo.FLAG_DEBUGGABLE) != 0
   }
 
@@ -151,8 +152,9 @@ class NfcWalletSuppressionPlugin internal constructor(
         SuppressionStatusCode.UNAVAILABLE, "NFC is disabled. Please enable NFC in device settings")))
       return
     }
-    // Already active (and NFC enabled): idempotent success without re-arming, so
-    // a failed re-arm can never leave the active flag inconsistent. Mirrors iOS.
+    // Already active (and NFC enabled): return idempotent success without
+    // re-arming, so a re-arm that failed could never leave the active flag
+    // inconsistent. Mirrors iOS.
     if (suppressionActive) {
       callback(Result.success(SuppressionResult(
         SuppressionStatusCode.SUPPRESSED, "Suppression already active")))
@@ -173,16 +175,33 @@ class NfcWalletSuppressionPlugin internal constructor(
   }
 
   override fun releaseSuppression(callback: (Result<SuppressionResult>) -> Unit) {
+    // Intent-based release (matches iOS): NOT_SUPPRESSED when we release a
+    // suppression that was requested, UNAVAILABLE when there was none to release.
+    // We deliberately do NOT reconcile against live state here (unlike
+    // isSuppressed) so request/release stays a clean pair and both platforms
+    // behave identically; isSuppressed is the API for live state.
     if (!suppressionActive) {
       callback(Result.success(SuppressionResult(
         SuppressionStatusCode.UNAVAILABLE, "No active suppression to release")))
       return
     }
-    activity?.let { activity ->
+    val activity = activity
+    if (activity != null) {
       try {
         suppressor.stopReaderMode(activity)
+      } catch (e: SecurityException) {
+        // Tear-down failed, so suppression is likely still active. Keep the flag
+        // truthful (do not clear it) and surface the failure, mirroring how
+        // requestSuppression maps exceptions.
+        if (isDebug) Log.e(TAG, "Security exception releasing suppression", e)
+        callback(Result.success(SuppressionResult(
+          SuppressionStatusCode.DENIED, "Permission denied for NFC operations: ${e.message}")))
+        return
       } catch (e: Exception) {
-        if (isDebug) Log.e(TAG, "Error stopping reader mode", e)
+        if (isDebug) Log.e(TAG, "Unexpected error releasing suppression", e)
+        callback(Result.success(SuppressionResult(
+          SuppressionStatusCode.UNKNOWN, "Failed to release suppression: ${e.message}")))
+        return
       }
     }
     suppressionActive = false
@@ -192,7 +211,7 @@ class NfcWalletSuppressionPlugin internal constructor(
 
   override fun isSuppressed(callback: (Result<Boolean>) -> Unit) {
     val activity = activity
-    // Reconcile intent with reality: reader mode only holds while an activity is
+    // Reconcile intent with reality: reader mode is only held while an activity is
     // attached and NFC is still enabled.
     val active = suppressionActive && activity != null && suppressor.isNfcEnabled(activity)
     callback(Result.success(active))

--- a/android/src/main/kotlin/dev/teklund/nfc_wallet_suppression/NfcWalletSuppressionPlugin.kt
+++ b/android/src/main/kotlin/dev/teklund/nfc_wallet_suppression/NfcWalletSuppressionPlugin.kt
@@ -1,9 +1,8 @@
 package dev.teklund.nfc_wallet_suppression
 
 import android.app.Activity
-import android.app.PendingIntent
 import android.content.Context
-import android.content.Intent
+import android.content.pm.ApplicationInfo
 import android.nfc.NfcAdapter
 import android.nfc.Tag
 import android.util.Log
@@ -11,26 +10,83 @@ import io.flutter.embedding.engine.plugins.FlutterPlugin
 import io.flutter.embedding.engine.plugins.activity.ActivityAware
 import io.flutter.embedding.engine.plugins.activity.ActivityPluginBinding
 
-/** NfcWalletSuppressionPlugin */
-class NfcWalletSuppressionPlugin: FlutterPlugin, ActivityAware,
-  NfcAdapter.ReaderCallback, NfcWalletSuppressionApi {
+/**
+ * Abstraction over the Android NFC reader-mode APIs.
+ *
+ * `NfcAdapter` is obtained through static factory calls, which makes the
+ * suppression logic impossible to unit test. Routing every adapter call through
+ * this interface lets the plugin be driven by a fake in tests while using the
+ * real adapter in production.
+ */
+interface WalletSuppressor {
+  fun hasNfcHardware(context: Context): Boolean
+  fun isNfcEnabled(context: Context): Boolean
 
-  private var suppressionActive : Boolean = false
-  private var activity : Activity? = null
-  private var context : Context? = null
-  private var isDebug : Boolean = false
-  
+  /**
+   * Enables reader mode for [activity]. Reader mode takes over the NFC stack,
+   * which suppresses wallet / host-card-emulation apps. Throws if it cannot be
+   * enabled (e.g. no adapter, security restriction).
+   */
+  fun startReaderMode(activity: Activity, callback: NfcAdapter.ReaderCallback)
+
+  fun stopReaderMode(activity: Activity)
+}
+
+/** Production implementation backed by [NfcAdapter]. */
+internal class SystemWalletSuppressor : WalletSuppressor {
+  override fun hasNfcHardware(context: Context): Boolean =
+    NfcAdapter.getDefaultAdapter(context) != null
+
+  override fun isNfcEnabled(context: Context): Boolean =
+    NfcAdapter.getDefaultAdapter(context)?.isEnabled == true
+
+  override fun startReaderMode(activity: Activity, callback: NfcAdapter.ReaderCallback) {
+    val adapter = NfcAdapter.getDefaultAdapter(activity)
+      ?: throw IllegalStateException("No NFC adapter available")
+    // Reader mode alone suppresses wallet/HCE; foreground dispatch is neither
+    // needed nor compatible. We do not read tags, so skip the NDEF check, and
+    // suppress the platform discovery sound for our silent reader session.
+    val flags = NfcAdapter.FLAG_READER_NFC_A or
+      NfcAdapter.FLAG_READER_NFC_B or
+      NfcAdapter.FLAG_READER_NFC_F or
+      NfcAdapter.FLAG_READER_NFC_V or
+      NfcAdapter.FLAG_READER_SKIP_NDEF_CHECK or
+      NfcAdapter.FLAG_READER_NO_PLATFORM_SOUNDS
+    adapter.enableReaderMode(activity, callback, flags, null)
+  }
+
+  override fun stopReaderMode(activity: Activity) {
+    NfcAdapter.getDefaultAdapter(activity)?.disableReaderMode(activity)
+  }
+}
+
+/** NfcWalletSuppressionPlugin */
+class NfcWalletSuppressionPlugin internal constructor(
+  private val suppressor: WalletSuppressor
+) : FlutterPlugin, ActivityAware, NfcAdapter.ReaderCallback, NfcWalletSuppressionApi {
+
+  constructor() : this(SystemWalletSuppressor())
+
+  private var activity: Activity? = null
+  private var context: Context? = null
+  private var isDebug: Boolean = false
+
+  /** Whether suppression is intended to be active (reader mode held). */
+  private var suppressionActive: Boolean = false
+
   companion object {
     private const val TAG = "NfcWalletSuppression"
   }
 
-  // Empty implementation - we only need ReaderCallback for reader mode flags,
-  // not for actual tag processing. The goal is to suppress wallet apps, not to read tags.
+  // Reader mode requires a callback, but we only occupy the NFC stack to
+  // suppress wallet apps; we do not process tags.
   override fun onTagDiscovered(tag: Tag?) {}
 
   override fun onAttachedToEngine(flutterPluginBinding: FlutterPlugin.FlutterPluginBinding) {
     NfcWalletSuppressionApi.setUp(flutterPluginBinding.binaryMessenger, this)
     context = flutterPluginBinding.applicationContext
+    // Set automatically by the build system (debug vs release); mirrors iOS #if DEBUG.
+    isDebug = ((context?.applicationInfo?.flags ?: 0) and ApplicationInfo.FLAG_DEBUGGABLE) != 0
   }
 
   override fun onDetachedFromEngine(binding: FlutterPlugin.FlutterPluginBinding) {
@@ -41,93 +97,39 @@ class NfcWalletSuppressionPlugin: FlutterPlugin, ActivityAware,
 
   override fun onAttachedToActivity(binding: ActivityPluginBinding) {
     activity = binding.activity
-    // Check if running in debug mode - set automatically by build system (debug vs release)
-    // Matches iOS's #if DEBUG behavior - no manual changes needed for production
-    isDebug = (activity?.applicationInfo?.flags?.and(android.content.pm.ApplicationInfo.FLAG_DEBUGGABLE) ?: 0) != 0
-  }
-
-  override fun onDetachedFromActivityForConfigChanges() {
-    // Clear the old Activity reference during configuration changes.
-    // Keep only minimal state (such as suppressionActive) for restoration on reattach.
-    activity = null
+    // Re-establish reader mode if suppression was active before this activity
+    // attached (configuration change or activity recreation). Reader mode is
+    // bound to an activity, so it must be re-armed against the new one.
+    if (suppressionActive) reestablish()
   }
 
   override fun onReattachedToActivityForConfigChanges(binding: ActivityPluginBinding) {
-    activity = binding.activity
-    
-    // Re-establish suppression if it was active before the configuration change
-    if (suppressionActive) {
-      reestablishSuppression()
-    }
+    onAttachedToActivity(binding)
+  }
+
+  override fun onDetachedFromActivityForConfigChanges() {
+    // Reader mode is torn down with the activity; it is re-armed on reattach.
+    activity = null
   }
 
   override fun onDetachedFromActivity() {
     activity = null
   }
 
-  override fun isSuppressed(callback: (Result<Boolean>) -> Unit) {
-    callback(Result.success(isSuppressedInternal()))
-  }
-
-  private fun isSuppressedInternal(): Boolean {
-    // Return false if no activity
-    val activity = activity ?: return false
-
-    // Return false if flag not set
-    if (!suppressionActive) return false
-
-    // Verify NFC is still available and enabled. suppressionActive may be stale
-    // if the user toggled NFC off in system settings after we called enableReaderMode.
-    val nfcAdapter = NfcAdapter.getDefaultAdapter(activity)
-    val actuallySuppressed = nfcAdapter != null && nfcAdapter.isEnabled
-
-    if (isDebug) {
-      Log.d(TAG, "isSuppressed check: actuallySuppressed=$actuallySuppressed (" +
-              "suppressionActive=$suppressionActive, nfcEnabled=${nfcAdapter?.isEnabled ?: false})")
-    }
-
-    return actuallySuppressed
-  }
-
-  private fun reestablishSuppression() {
-    if (isDebug) Log.d(TAG, "Reestablishing NFC suppression after configuration change")
-    val activity = activity
-    if (activity == null) {
-      if (isDebug) Log.w(TAG, "Cannot reestablish suppression: no activity attached")
+  /** Re-arms reader mode against the current activity. Precondition: suppressionActive. */
+  private fun reestablish() {
+    val activity = activity ?: return
+    if (!suppressor.isNfcEnabled(activity)) {
+      // NFC was turned off while detached; suppression can no longer be held.
+      if (isDebug) Log.w(TAG, "Cannot re-establish suppression: NFC not enabled")
       suppressionActive = false
       return
     }
-    val nfcAdapter = NfcAdapter.getDefaultAdapter(activity)
-    if (nfcAdapter == null || !nfcAdapter.isEnabled) {
-      if (isDebug) Log.w(TAG, "Cannot reestablish suppression: NFC not available")
-      suppressionActive = false
-      return
-    }
-
-    val intent = Intent(activity, activity.javaClass).apply {
-      addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP)
-    }
-    val pendingIntent: PendingIntent = PendingIntent.getActivity(
-      activity,
-      0,
-      intent,
-      PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT
-    )
-
-    nfcAdapter.enableForegroundDispatch(activity, pendingIntent, null, null)
-
-    // Read all techs, skip NDEF to skip P2P
-    val flags: Int = NfcAdapter.FLAG_READER_NFC_A or
-            NfcAdapter.FLAG_READER_NFC_B or
-            NfcAdapter.FLAG_READER_NFC_F or
-            NfcAdapter.FLAG_READER_NFC_V or
-            NfcAdapter.FLAG_READER_SKIP_NDEF_CHECK
-
     try {
-      nfcAdapter.enableReaderMode(activity, this, flags, null)
-      if (isDebug) Log.d(TAG, "Reestablished NFC suppression")
+      suppressor.startReaderMode(activity, this)
+      if (isDebug) Log.d(TAG, "Re-established NFC suppression")
     } catch (e: Exception) {
-      if (isDebug) Log.e(TAG, "Failed to reestablish suppression", e)
+      if (isDebug) Log.e(TAG, "Failed to re-establish suppression", e)
       suppressionActive = false
     }
   }
@@ -135,145 +137,73 @@ class NfcWalletSuppressionPlugin: FlutterPlugin, ActivityAware,
   override fun requestSuppression(callback: (Result<SuppressionResult>) -> Unit) {
     val activity = activity
     if (activity == null) {
-      if (isDebug) Log.e(TAG, "Request suppression failed: Activity is null")
       callback(Result.success(SuppressionResult(
-        status = SuppressionStatusCode.UNAVAILABLE,
-        message = "Activity not available"
-      )))
+        SuppressionStatusCode.UNAVAILABLE, "Activity not available")))
       return
     }
-    
-    val nfcAdapter = NfcAdapter.getDefaultAdapter(activity)
-    
-    if (nfcAdapter == null) {
-      if (isDebug) Log.e(TAG, "Request suppression failed: No NFC hardware")
+    if (!suppressor.hasNfcHardware(activity)) {
       callback(Result.success(SuppressionResult(
-        status = SuppressionStatusCode.NOT_SUPPORTED,
-        message = "Device does not have NFC hardware"
-      )))
+        SuppressionStatusCode.NOT_SUPPORTED, "Device does not have NFC hardware")))
       return
     }
-    
-    if (!nfcAdapter.isEnabled) {
-      if (isDebug) Log.w(TAG, "Request suppression failed: NFC is disabled")
+    if (!suppressor.isNfcEnabled(activity)) {
       callback(Result.success(SuppressionResult(
-        status = SuppressionStatusCode.UNAVAILABLE,
-        message = "NFC is disabled. Please enable NFC in device settings"
-      )))
+        SuppressionStatusCode.UNAVAILABLE, "NFC is disabled. Please enable NFC in device settings")))
       return
     }
-
+    // Already active (and NFC enabled): idempotent success without re-arming, so
+    // a failed re-arm can never leave the active flag inconsistent. Mirrors iOS.
+    if (suppressionActive) {
+      callback(Result.success(SuppressionResult(
+        SuppressionStatusCode.SUPPRESSED, "Suppression already active")))
+      return
+    }
     try {
-      val intent = Intent(activity, activity.javaClass).apply {
-        addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP)
-      }
-      val pendingIntent: PendingIntent = PendingIntent.getActivity(
-        activity,
-        0,
-        intent,
-        PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT
-      )
-
-      nfcAdapter.enableForegroundDispatch(activity, pendingIntent, null, null)
-
-      // Read all techs, skip NDEF to skip P2P
-      val flags: Int = NfcAdapter.FLAG_READER_NFC_A or
-              NfcAdapter.FLAG_READER_NFC_B or
-              NfcAdapter.FLAG_READER_NFC_F or
-              NfcAdapter.FLAG_READER_NFC_V or
-              NfcAdapter.FLAG_READER_SKIP_NDEF_CHECK
-
-      nfcAdapter.enableReaderMode(activity, this, flags, null)
+      suppressor.startReaderMode(activity, this)
       suppressionActive = true
-      if (isDebug) Log.d(TAG, "NFC wallet suppression enabled successfully")
-      callback(Result.success(SuppressionResult(
-        status = SuppressionStatusCode.SUPPRESSED,
-        message = "Suppressed"
-      )))
+      if (isDebug) Log.d(TAG, "NFC wallet suppression enabled")
+      callback(Result.success(SuppressionResult(SuppressionStatusCode.SUPPRESSED, "Suppressed")))
     } catch (e: SecurityException) {
-      if (isDebug) Log.e(TAG, "Security exception requesting suppression", e)
       callback(Result.success(SuppressionResult(
-        status = SuppressionStatusCode.DENIED,
-        message = "Permission denied for NFC operations: ${e.message}"
-      )))
+        SuppressionStatusCode.DENIED, "Permission denied for NFC operations: ${e.message}")))
     } catch (e: Exception) {
-      if (isDebug) Log.e(TAG, "Unexpected error requesting suppression", e)
       callback(Result.success(SuppressionResult(
-        status = SuppressionStatusCode.UNKNOWN,
-        message = "Failed to request suppression: ${e.message}"
-      )))
+        SuppressionStatusCode.UNKNOWN, "Failed to request suppression: ${e.message}")))
     }
   }
 
   override fun releaseSuppression(callback: (Result<SuppressionResult>) -> Unit) {
-    val activity = activity
-    if (activity == null) {
-      // If there is no activity there is nothing to release.
-      if (isDebug) Log.d(TAG, "Release suppression: no activity attached, nothing to release")
-      suppressionActive = false
+    if (!suppressionActive) {
       callback(Result.success(SuppressionResult(
-        status = SuppressionStatusCode.NOT_SUPPRESSED,
-        message = "Suppression released"
-      )))
+        SuppressionStatusCode.UNAVAILABLE, "No active suppression to release")))
       return
     }
-    
-    val nfcAdapter = NfcAdapter.getDefaultAdapter(activity)
-    
-    if (nfcAdapter == null) {
-      if (isDebug) Log.w(TAG, "Release suppression: No NFC adapter (already released or device has no NFC)")
-      // Still mark as not suppressed and return success
-      suppressionActive = false
-      callback(Result.success(SuppressionResult(
-        status = SuppressionStatusCode.NOT_SUPPRESSED,
-        message = "Suppression released"
-      )))
-      return
-    }
-    
-    try {
-      if (nfcAdapter.isEnabled) {
-        nfcAdapter.disableForegroundDispatch(activity)
-        nfcAdapter.disableReaderMode(activity)
-        if (isDebug) Log.d(TAG, "NFC wallet suppression disabled successfully")
-      } else {
-        if (isDebug) Log.w(TAG, "NFC is disabled, skipping disable operations")
+    activity?.let { activity ->
+      try {
+        suppressor.stopReaderMode(activity)
+      } catch (e: Exception) {
+        if (isDebug) Log.e(TAG, "Error stopping reader mode", e)
       }
-      suppressionActive = false
-      callback(Result.success(SuppressionResult(
-        status = SuppressionStatusCode.NOT_SUPPRESSED,
-        message = "Suppression released"
-      )))
-    } catch (e: SecurityException) {
-      if (isDebug) Log.e(TAG, "Security exception releasing suppression", e)
-      suppressionActive = false  // Mark as not suppressed anyway
-      callback(Result.success(SuppressionResult(
-        status = SuppressionStatusCode.DENIED,
-        message = "Permission denied for NFC operations: ${e.message}"
-      )))
-    } catch (e: Exception) {
-      if (isDebug) Log.e(TAG, "Unexpected error releasing suppression", e)
-      suppressionActive = false  // Mark as not suppressed anyway
-      callback(Result.success(SuppressionResult(
-        status = SuppressionStatusCode.UNKNOWN,
-        message = "Failed to release suppression: ${e.message}"
-      )))
     }
+    suppressionActive = false
+    callback(Result.success(SuppressionResult(
+      SuppressionStatusCode.NOT_SUPPRESSED, "Suppression released")))
+  }
+
+  override fun isSuppressed(callback: (Result<Boolean>) -> Unit) {
+    val activity = activity
+    // Reconcile intent with reality: reader mode only holds while an activity is
+    // attached and NFC is still enabled.
+    val active = suppressionActive && activity != null && suppressor.isNfcEnabled(activity)
+    callback(Result.success(active))
   }
 
   override fun isSupported(callback: (Result<Boolean>) -> Unit) {
-    // Check if device has NFC hardware (requires API 21+)
-    // Use application context so this works even if activity is not attached yet
-    val currentContext = context ?: activity
-    if (currentContext == null) {
-      if (isDebug) Log.w(TAG, "isSupported: No context available")
+    val ctx = context ?: activity
+    if (ctx == null) {
       callback(Result.success(false))
       return
     }
-
-    val nfcAdapter = NfcAdapter.getDefaultAdapter(currentContext)
-    val supported = nfcAdapter != null
-    if (isDebug) Log.d(TAG, "isSupported called: $supported (NFC adapter: ${if (nfcAdapter != null) "present" else "null"})")
-    callback(Result.success(supported))
+    callback(Result.success(suppressor.hasNfcHardware(ctx)))
   }
 }

--- a/android/src/test/kotlin/dev/teklund/nfc_wallet_suppression/NfcWalletSuppressionPluginTest.kt
+++ b/android/src/test/kotlin/dev/teklund/nfc_wallet_suppression/NfcWalletSuppressionPluginTest.kt
@@ -1,101 +1,220 @@
 package dev.teklund.nfc_wallet_suppression
 
+import android.app.Activity
+import android.content.Context
+import android.nfc.NfcAdapter
+import io.flutter.embedding.engine.plugins.activity.ActivityPluginBinding
 import kotlin.test.Test
-import kotlin.test.assertTrue
-import kotlin.test.assertFalse
-import kotlin.test.assertNotNull
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import org.mockito.Mockito
 
-/*
- * Unit tests for NfcWalletSuppressionPlugin focusing on state persistence
- * across activity lifecycle events (Task 3 validation).
+/**
+ * Unit tests for [NfcWalletSuppressionPlugin].
  *
- * Run these tests from the command line: `./gradlew testDebugUnitTest` in `example/android/`
- * or directly from Android Studio.
+ * The plugin's NFC access is routed through [WalletSuppressor], so these tests
+ * drive a [FakeWalletSuppressor] and use a mock [Activity] as an opaque token —
+ * exercising the real suppression/release/lifecycle paths without a device.
+ *
+ * Run via `./gradlew testDebugUnitTest` in `example/android/`.
  */
-
 internal class NfcWalletSuppressionPluginTest {
 
-  @Test
-  fun isSuppressed_returnsFalseWhenNoActivity() {
-    val plugin = NfcWalletSuppressionPlugin()
-    // No activity attached, so isSuppressed should be false
-    
-    plugin.isSuppressed { result ->
-        assertTrue(result.isSuccess)
-        assertFalse(result.getOrNull()!!)
+  /** Controllable fake of the NFC reader-mode API. */
+  private class FakeWalletSuppressor : WalletSuppressor {
+    var hasHardware = true
+    var nfcEnabled = true
+    var startError: Exception? = null
+    var startCount = 0
+    var stopCount = 0
+
+    override fun hasNfcHardware(context: Context) = hasHardware
+    override fun isNfcEnabled(context: Context) = nfcEnabled
+    override fun startReaderMode(activity: Activity, callback: NfcAdapter.ReaderCallback) {
+      startError?.let { throw it }
+      startCount++
+    }
+    override fun stopReaderMode(activity: Activity) {
+      stopCount++
     }
   }
 
-  @Test
-  fun requestSuppression_returnsUnavailableWhenNoActivity() {
-    val plugin = NfcWalletSuppressionPlugin()
-    
-    plugin.requestSuppression { result ->
-        assertTrue(result.isSuccess)
-        val suppressionResult = result.getOrNull()
-        assertNotNull(suppressionResult)
-        assertEquals(SuppressionStatusCode.UNAVAILABLE, suppressionResult.status)
-        assertEquals("Activity not available", suppressionResult.message)
-    }
-  }
-  
-  @Test
-  fun releaseSuppression_returnsNotSuppressedWhenNoActivity() {
-    val plugin = NfcWalletSuppressionPlugin()
-
-    plugin.releaseSuppression { result ->
-        assertTrue(result.isSuccess)
-        val suppressionResult = result.getOrNull()
-        assertNotNull(suppressionResult)
-        assertEquals(SuppressionStatusCode.NOT_SUPPRESSED, suppressionResult.status)
-        assertEquals("Suppression released", suppressionResult.message)
-    }
+  private fun activityBinding(activity: Activity): ActivityPluginBinding {
+    val binding = Mockito.mock(ActivityPluginBinding::class.java)
+    Mockito.`when`(binding.activity).thenReturn(activity)
+    return binding
   }
 
-  @Test
-  fun isSupported_returnsFalseWhenNoContext() {
-    val plugin = NfcWalletSuppressionPlugin()
-    plugin.isSupported { result ->
-      assertTrue(result.isSuccess)
-      assertFalse(result.getOrNull()!!)
-    }
+  private fun pluginWithActivity(
+    fake: FakeWalletSuppressor,
+    activity: Activity = Mockito.mock(Activity::class.java),
+  ): NfcWalletSuppressionPlugin {
+    val plugin = NfcWalletSuppressionPlugin(fake)
+    plugin.onAttachedToActivity(activityBinding(activity))
+    return plugin
   }
 
+  private fun requestStatus(plugin: NfcWalletSuppressionPlugin): SuppressionStatusCode {
+    var status: SuppressionStatusCode? = null
+    plugin.requestSuppression { status = it.getOrNull()?.status }
+    return status!!
+  }
+
+  private fun releaseStatus(plugin: NfcWalletSuppressionPlugin): SuppressionStatusCode {
+    var status: SuppressionStatusCode? = null
+    plugin.releaseSuppression { status = it.getOrNull()?.status }
+    return status!!
+  }
+
+  private fun suppressed(plugin: NfcWalletSuppressionPlugin): Boolean {
+    var value = false
+    plugin.isSuppressed { value = it.getOrNull()!! }
+    return value
+  }
+
+  private fun supported(plugin: NfcWalletSuppressionPlugin): Boolean {
+    var value = false
+    plugin.isSupported { value = it.getOrNull()!! }
+    return value
+  }
+
+  // requestSuppression
+
   @Test
-  fun requestSuppression_returnsNotSupportedWhenNoNfcDevice() {
-    val plugin = NfcWalletSuppressionPlugin()
-    val binding = org.mockito.Mockito.mock(io.flutter.embedding.engine.plugins.activity.ActivityPluginBinding::class.java)
-    val activity = org.mockito.Mockito.mock(android.app.Activity::class.java)
-    org.mockito.Mockito.`when`(binding.activity).thenReturn(activity)
-    
-    plugin.onAttachedToActivity(binding)
-    // When no NFC is available on the device, NfcAdapter.getDefaultAdapter returns null
-    plugin.requestSuppression { result ->
-        assertTrue(result.isSuccess)
-        val suppressionResult = result.getOrNull()
-        assertNotNull(suppressionResult)
-        assertEquals(SuppressionStatusCode.NOT_SUPPORTED, suppressionResult.status)
-        assertEquals("Device does not have NFC hardware", suppressionResult.message)
-    }
+  fun request_returnsUnavailableWhenNoActivity() {
+    val plugin = NfcWalletSuppressionPlugin(FakeWalletSuppressor())
+    assertEquals(SuppressionStatusCode.UNAVAILABLE, requestStatus(plugin))
   }
 
   @Test
-  fun releaseSuppression_returnsNotSuppressedWhenNoNfcDevice() {
-    val plugin = NfcWalletSuppressionPlugin()
-    val binding = org.mockito.Mockito.mock(io.flutter.embedding.engine.plugins.activity.ActivityPluginBinding::class.java)
-    val activity = org.mockito.Mockito.mock(android.app.Activity::class.java)
-    org.mockito.Mockito.`when`(binding.activity).thenReturn(activity)
-    
-    plugin.onAttachedToActivity(binding)
-    
-    plugin.releaseSuppression { result ->
-        assertTrue(result.isSuccess)
-        val suppressionResult = result.getOrNull()
-        assertNotNull(suppressionResult)
-        assertEquals(SuppressionStatusCode.NOT_SUPPRESSED, suppressionResult.status)
-        assertEquals("Suppression released", suppressionResult.message)
-    }
+  fun request_returnsNotSupportedWhenNoNfcHardware() {
+    val fake = FakeWalletSuppressor().apply { hasHardware = false }
+    assertEquals(SuppressionStatusCode.NOT_SUPPORTED, requestStatus(pluginWithActivity(fake)))
+  }
+
+  @Test
+  fun request_returnsUnavailableWhenNfcDisabled() {
+    val fake = FakeWalletSuppressor().apply { nfcEnabled = false }
+    assertEquals(SuppressionStatusCode.UNAVAILABLE, requestStatus(pluginWithActivity(fake)))
+  }
+
+  @Test
+  fun request_success_enablesReaderModeAndReportsSuppressed() {
+    val fake = FakeWalletSuppressor()
+    val plugin = pluginWithActivity(fake)
+    assertEquals(SuppressionStatusCode.SUPPRESSED, requestStatus(plugin))
+    assertEquals(1, fake.startCount)
+    assertTrue(suppressed(plugin))
+  }
+
+  @Test
+  fun request_whenAlreadyActive_returnsSuppressedWithoutReArming() {
+    val fake = FakeWalletSuppressor()
+    val plugin = pluginWithActivity(fake)
+    requestStatus(plugin)
+    assertEquals(1, fake.startCount)
+
+    assertEquals(SuppressionStatusCode.SUPPRESSED, requestStatus(plugin))
+    assertEquals(1, fake.startCount, "Must not re-arm reader mode when already active")
+  }
+
+  @Test
+  fun request_securityException_returnsDenied() {
+    val fake = FakeWalletSuppressor().apply { startError = SecurityException("nope") }
+    assertEquals(SuppressionStatusCode.DENIED, requestStatus(pluginWithActivity(fake)))
+  }
+
+  @Test
+  fun request_genericException_returnsUnknown() {
+    val fake = FakeWalletSuppressor().apply { startError = IllegalStateException("boom") }
+    assertEquals(SuppressionStatusCode.UNKNOWN, requestStatus(pluginWithActivity(fake)))
+  }
+
+  // releaseSuppression
+
+  @Test
+  fun release_withoutActiveSuppression_returnsUnavailable() {
+    val plugin = pluginWithActivity(FakeWalletSuppressor())
+    assertEquals(SuppressionStatusCode.UNAVAILABLE, releaseStatus(plugin))
+  }
+
+  @Test
+  fun release_whenActive_disablesReaderModeAndReportsNotSuppressed() {
+    val fake = FakeWalletSuppressor()
+    val plugin = pluginWithActivity(fake)
+    requestStatus(plugin)
+    assertEquals(SuppressionStatusCode.NOT_SUPPRESSED, releaseStatus(plugin))
+    assertEquals(1, fake.stopCount)
+    assertFalse(suppressed(plugin))
+  }
+
+  // isSuppressed / isSupported
+
+  @Test
+  fun isSuppressed_falseWhenNoActivity() {
+    assertFalse(suppressed(NfcWalletSuppressionPlugin(FakeWalletSuppressor())))
+  }
+
+  @Test
+  fun isSuppressed_falseWhenActiveButNfcDisabled() {
+    val fake = FakeWalletSuppressor()
+    val plugin = pluginWithActivity(fake)
+    requestStatus(plugin)
+    fake.nfcEnabled = false  // user turned NFC off after suppressing
+    assertFalse(suppressed(plugin))
+  }
+
+  @Test
+  fun isSupported_reflectsHardwarePresence() {
+    assertTrue(supported(pluginWithActivity(FakeWalletSuppressor().apply { hasHardware = true })))
+    assertFalse(supported(pluginWithActivity(FakeWalletSuppressor().apply { hasHardware = false })))
+  }
+
+  // lifecycle
+
+  @Test
+  fun configurationChange_reArmsReaderModeOnReattach() {
+    val fake = FakeWalletSuppressor()
+    val activity = Mockito.mock(Activity::class.java)
+    val plugin = pluginWithActivity(fake, activity)
+    requestStatus(plugin)
+    assertEquals(1, fake.startCount)
+
+    plugin.onDetachedFromActivityForConfigChanges()
+    plugin.onReattachedToActivityForConfigChanges(activityBinding(activity))
+
+    assertEquals(2, fake.startCount, "Reader mode must be re-armed against the new activity")
+    assertTrue(suppressed(plugin))
+  }
+
+  @Test
+  fun reattach_whenNfcDisabled_dropsSuppression() {
+    val fake = FakeWalletSuppressor()
+    val activity = Mockito.mock(Activity::class.java)
+    val plugin = pluginWithActivity(fake, activity)
+    requestStatus(plugin)
+
+    fake.nfcEnabled = false  // NFC turned off while detached
+    plugin.onDetachedFromActivityForConfigChanges()
+    plugin.onReattachedToActivityForConfigChanges(activityBinding(activity))
+
+    assertEquals(1, fake.startCount, "Must not re-arm when NFC is disabled")
+    assertFalse(suppressed(plugin))
+  }
+
+  @Test
+  fun permanentDetachThenReattach_reArmsReaderMode() {
+    val fake = FakeWalletSuppressor()
+    val activity = Mockito.mock(Activity::class.java)
+    val plugin = pluginWithActivity(fake, activity)
+    requestStatus(plugin)
+
+    plugin.onDetachedFromActivity()
+    assertFalse(suppressed(plugin), "No activity -> not actually suppressed")
+
+    plugin.onAttachedToActivity(activityBinding(activity))
+    assertEquals(2, fake.startCount)
+    assertTrue(suppressed(plugin))
   }
 }
-

--- a/android/src/test/kotlin/dev/teklund/nfc_wallet_suppression/NfcWalletSuppressionPluginTest.kt
+++ b/android/src/test/kotlin/dev/teklund/nfc_wallet_suppression/NfcWalletSuppressionPluginTest.kt
@@ -3,7 +3,9 @@ package dev.teklund.nfc_wallet_suppression
 import android.app.Activity
 import android.content.Context
 import android.nfc.NfcAdapter
+import io.flutter.embedding.engine.plugins.FlutterPlugin
 import io.flutter.embedding.engine.plugins.activity.ActivityPluginBinding
+import io.flutter.plugin.common.BinaryMessenger
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -14,8 +16,9 @@ import org.mockito.Mockito
  * Unit tests for [NfcWalletSuppressionPlugin].
  *
  * The plugin's NFC access is routed through [WalletSuppressor], so these tests
- * drive a [FakeWalletSuppressor] and use a mock [Activity] as an opaque token —
- * exercising the real suppression/release/lifecycle paths without a device.
+ * drive a [FakeWalletSuppressor] and use a mock [Activity] as an opaque
+ * placeholder — exercising the real suppression/release/lifecycle paths without
+ * a device.
  *
  * Run via `./gradlew testDebugUnitTest` in `example/android/`.
  */
@@ -26,6 +29,7 @@ internal class NfcWalletSuppressionPluginTest {
     var hasHardware = true
     var nfcEnabled = true
     var startError: Exception? = null
+    var stopError: Exception? = null
     var startCount = 0
     var stopCount = 0
 
@@ -36,6 +40,7 @@ internal class NfcWalletSuppressionPluginTest {
       startCount++
     }
     override fun stopReaderMode(activity: Activity) {
+      stopError?.let { throw it }
       stopCount++
     }
   }
@@ -140,6 +145,28 @@ internal class NfcWalletSuppressionPluginTest {
   }
 
   @Test
+  fun release_whenStopThrowsSecurityException_reportsDeniedAndStaysSuppressed() {
+    val fake = FakeWalletSuppressor()
+    val plugin = pluginWithActivity(fake)
+    requestStatus(plugin)
+
+    fake.stopError = SecurityException("denied")
+    assertEquals(SuppressionStatusCode.DENIED, releaseStatus(plugin))
+    assertTrue(suppressed(plugin), "A failed tear-down must keep suppression active (truthful)")
+  }
+
+  @Test
+  fun release_whenStopThrowsGenericException_reportsUnknownAndStaysSuppressed() {
+    val fake = FakeWalletSuppressor()
+    val plugin = pluginWithActivity(fake)
+    requestStatus(plugin)
+
+    fake.stopError = IllegalStateException("boom")
+    assertEquals(SuppressionStatusCode.UNKNOWN, releaseStatus(plugin))
+    assertTrue(suppressed(plugin))
+  }
+
+  @Test
   fun release_whenActive_disablesReaderModeAndReportsNotSuppressed() {
     val fake = FakeWalletSuppressor()
     val plugin = pluginWithActivity(fake)
@@ -169,6 +196,20 @@ internal class NfcWalletSuppressionPluginTest {
   fun isSupported_reflectsHardwarePresence() {
     assertTrue(supported(pluginWithActivity(FakeWalletSuppressor().apply { hasHardware = true })))
     assertFalse(supported(pluginWithActivity(FakeWalletSuppressor().apply { hasHardware = false })))
+  }
+
+  @Test
+  fun isSupported_usesApplicationContextWhenNoActivityAttached() {
+    val fake = FakeWalletSuppressor().apply { hasHardware = true }
+    val plugin = NfcWalletSuppressionPlugin(fake)
+    // Attach the engine (sets the application context) but no activity, mirroring
+    // a call made before the activity attaches.
+    val engineBinding = Mockito.mock(FlutterPlugin.FlutterPluginBinding::class.java)
+    Mockito.`when`(engineBinding.binaryMessenger).thenReturn(Mockito.mock(BinaryMessenger::class.java))
+    Mockito.`when`(engineBinding.applicationContext).thenReturn(Mockito.mock(Context::class.java))
+    plugin.onAttachedToEngine(engineBinding)
+
+    assertTrue(supported(plugin), "isSupported must work via application context without an activity")
   }
 
   // lifecycle
@@ -201,6 +242,26 @@ internal class NfcWalletSuppressionPluginTest {
 
     assertEquals(1, fake.startCount, "Must not re-arm when NFC is disabled")
     assertFalse(suppressed(plugin))
+  }
+
+  @Test
+  fun reattach_whenReArmThrows_dropsSuppression() {
+    val fake = FakeWalletSuppressor()
+    val activity = Mockito.mock(Activity::class.java)
+    val plugin = pluginWithActivity(fake, activity)
+    requestStatus(plugin)
+
+    // Re-arming reader mode fails on reattach (e.g. SecurityException).
+    fake.startError = SecurityException("denied")
+    plugin.onDetachedFromActivityForConfigChanges()
+    plugin.onReattachedToActivityForConfigChanges(activityBinding(activity))
+
+    assertFalse(suppressed(plugin), "A failed re-arm must drop suppression")
+    assertEquals(
+      SuppressionStatusCode.UNAVAILABLE,
+      releaseStatus(plugin),
+      "suppressionActive must have been cleared on re-arm failure",
+    )
   }
 
   @Test

--- a/example/ios/RunnerTests/RunnerTests.swift
+++ b/example/ios/RunnerTests/RunnerTests.swift
@@ -182,6 +182,30 @@ class RunnerTests: XCTestCase {
     XCTAssertEqual(status, .suppressed)
   }
 
+  func testRequest_whenActiveButOsEnded_reRequestThatFailsGoesIdle() {
+    let fake = FakePassLibrary()
+    fake.tokenToReturn = 8
+    let plugin = NfcWalletSuppressionPlugin(library: fake)
+
+    plugin.requestSuppression { _ in }
+    fake.deliver(.success)  // active, token 8
+    fake.isSuppressingAutomaticPassPresentation = false  // OS ended it externally
+    fake.tokenToReturn = 9
+
+    var status: SuppressionStatusCode?
+    plugin.requestSuppression { status = (try? $0.get())?.status }
+    fake.deliver(.denied)  // the fresh re-request fails
+
+    XCTAssertEqual(status, .denied)
+    XCTAssertEqual(fake.endedTokens, [8, 9],
+                   "Stale token 8 released before re-request; failed request's token 9 released too")
+
+    // State is idle, so a subsequent release reports unavailable.
+    var releaseStatus: SuppressionStatusCode?
+    plugin.releaseSuppression { releaseStatus = (try? $0.get())?.status }
+    XCTAssertEqual(releaseStatus, .unavailable)
+  }
+
   // MARK: - releaseSuppression
 
   func testRelease_fromIdle_returnsUnavailable() {

--- a/example/ios/RunnerTests/RunnerTests.swift
+++ b/example/ios/RunnerTests/RunnerTests.swift
@@ -1,79 +1,278 @@
 import Flutter
 import UIKit
+import PassKit
 import XCTest
-
 
 @testable import nfc_wallet_suppression
 
-// This demonstrates a simple unit test of the Swift portion of this plugin's implementation.
-//
-// See https://developer.apple.com/documentation/xctest for more information about using XCTest.
+/// Controllable fake of the PassKit suppression API.
+///
+/// Mirrors PassKit's contract: `requestSuppression` returns the token
+/// synchronously and the response handler fires later, when the test calls
+/// `deliver(_:)`. (In production `SystemPassLibrary` guarantees the handler is
+/// delivered asynchronously on the main thread, so synchronous delivery is not
+/// modelled here.)
+final class FakePassLibrary: PassPresentationSuppressing {
+  var isPassLibraryAvailable = false
+  var isSuppressingAutomaticPassPresentation = false
+
+  /// Token returned by `requestSuppression`. `0` models a request that could
+  /// not be submitted (handler never fires).
+  var tokenToReturn: PKSuppressionRequestToken = 1
+
+  private(set) var requestCount = 0
+  private(set) var endedTokens: [PKSuppressionRequestToken] = []
+  private var pendingHandler: ((PKAutomaticPassPresentationSuppressionResult) -> Void)?
+
+  func requestSuppression(
+    responseHandler: @escaping (PKAutomaticPassPresentationSuppressionResult) -> Void
+  ) -> PKSuppressionRequestToken {
+    requestCount += 1
+    pendingHandler = responseHandler
+    return tokenToReturn
+  }
+
+  func endSuppression(withRequestToken token: PKSuppressionRequestToken) {
+    endedTokens.append(token)
+  }
+
+  /// Simulate PassKit invoking the response handler.
+  func deliver(_ result: PKAutomaticPassPresentationSuppressionResult) {
+    let handler = pendingHandler
+    pendingHandler = nil
+    handler?(result)
+  }
+}
 
 class RunnerTests: XCTestCase {
-    
-    var plugin: NfcWalletSuppressionPlugin!
-    
-    override func setUp() {
-        super.setUp()
-        plugin = NfcWalletSuppressionPlugin()
+
+  // MARK: - Pure result mapping
+
+  func testMapping_coversEverySuppressionResult() {
+    XCTAssertEqual(NfcWalletSuppressionPlugin.suppressionResult(for: .success).status, .suppressed)
+    XCTAssertEqual(NfcWalletSuppressionPlugin.suppressionResult(for: .notSupported).status, .notSupported)
+    XCTAssertEqual(NfcWalletSuppressionPlugin.suppressionResult(for: .alreadyPresenting).status, .alreadyPresenting)
+    XCTAssertEqual(NfcWalletSuppressionPlugin.suppressionResult(for: .cancelled).status, .cancelled)
+    XCTAssertEqual(NfcWalletSuppressionPlugin.suppressionResult(for: .denied).status, .denied)
+  }
+
+  // MARK: - requestSuppression
+
+  func testRequest_success_becomesActiveAndReportsSuppressed() {
+    let fake = FakePassLibrary()
+    fake.tokenToReturn = 42
+    let plugin = NfcWalletSuppressionPlugin(library: fake)
+
+    var status: SuppressionStatusCode?
+    plugin.requestSuppression { status = (try? $0.get())?.status }
+    fake.deliver(.success)
+
+    XCTAssertEqual(status, .suppressed)
+    XCTAssertEqual(fake.requestCount, 1)
+    XCTAssertTrue(fake.endedTokens.isEmpty, "A successful request must not release its token")
+  }
+
+  func testRequest_failure_releasesTokenAndReportsStatus() {
+    let fake = FakePassLibrary()
+    fake.tokenToReturn = 7
+    let plugin = NfcWalletSuppressionPlugin(library: fake)
+
+    var status: SuppressionStatusCode?
+    plugin.requestSuppression { status = (try? $0.get())?.status }
+    fake.deliver(.denied)
+
+    XCTAssertEqual(status, .denied)
+    XCTAssertEqual(fake.endedTokens, [7], "A failed request must release the issued token")
+
+    var releaseStatus: SuppressionStatusCode?
+    plugin.releaseSuppression { releaseStatus = (try? $0.get())?.status }
+    XCTAssertEqual(releaseStatus, .unavailable, "No token should linger after a failed request")
+  }
+
+  func testRequest_zeroToken_reportsUnknownWithoutHandler() {
+    let fake = FakePassLibrary()
+    fake.tokenToReturn = 0  // could not be submitted; handler never fires
+    let plugin = NfcWalletSuppressionPlugin(library: fake)
+
+    var callCount = 0
+    var status: SuppressionStatusCode?
+    plugin.requestSuppression {
+      callCount += 1
+      status = (try? $0.get())?.status
     }
-    
-    override func tearDown() {
-        plugin = nil
-        super.tearDown()
-    }
-    
-    /// Test default isSuppressed state
-    func testIsSuppressed_defaultsToFalse() {
-        let expectation = self.expectation(description: "isSuppressed completes")
-        
-        plugin.isSuppressed { result in
-            switch result {
-            case .success(let suppressed):
-                XCTAssertFalse(suppressed, "Default suppression state should be false")
-            case .failure(let error):
-                XCTFail("isSuppressed failed with error: \(error)")
-            }
-            expectation.fulfill()
-        }
-        
-        waitForExpectations(timeout: 1.0)
-    }
-    
-    /// Test that releaseSuppression returns unavailable when no token exists (idempotent)
-    func testReleaseSuppression_withoutRequest_returnsUnavailable() {
-        let expectation = self.expectation(description: "releaseSuppression completes")
-        
-        plugin.releaseSuppression { result in
-            switch result {
-            case .success(let suppressionResult):
-                // Based on implementation, releasing without token returns UNAVAILABLE
-                XCTAssertEqual(suppressionResult.status, .unavailable)
-                XCTAssertEqual(suppressionResult.message, "No active suppression to release")
-            case .failure(let error):
-                XCTFail("releaseSuppression failed with error: \(error)")
-            }
-            expectation.fulfill()
-        }
-        
-        waitForExpectations(timeout: 1.0)
-    }
-    
-    /// Test isSupported (will likely return false on Simulator)
-    func testIsSupported_returnsResult() {
-        let expectation = self.expectation(description: "isSupported completes")
-        
-        plugin.isSupported { result in
-            switch result {
-            case .success:
-                // Just verifying it returns a success result, boolean depends on simulator environment
-                XCTAssertTrue(true)
-            case .failure(let error):
-                XCTFail("isSupported failed with error: \(error)")
-            }
-            expectation.fulfill()
-        }
-        
-        waitForExpectations(timeout: 1.0)
-    }
+    // Deliberately never deliver a handler result.
+
+    XCTAssertEqual(callCount, 1, "completion must fire even if PassKit never calls the handler")
+    XCTAssertEqual(status, .unknown)
+    XCTAssertTrue(fake.endedTokens.isEmpty, "Must never end a 0 token")
+  }
+
+  func testRequest_coalescedRequestAndDeferredReleaseResolveTogether() {
+    let fake = FakePassLibrary()
+    fake.tokenToReturn = 21
+    let plugin = NfcWalletSuppressionPlugin(library: fake)
+
+    var first: SuppressionStatusCode?
+    var second: SuppressionStatusCode?
+    var release: SuppressionStatusCode?
+    plugin.requestSuppression { first = (try? $0.get())?.status }
+    plugin.requestSuppression { second = (try? $0.get())?.status }  // coalesces
+    plugin.releaseSuppression { release = (try? $0.get())?.status }  // defers
+
+    XCTAssertEqual(fake.requestCount, 1)
+    XCTAssertTrue(fake.endedTokens.isEmpty)
+
+    fake.deliver(.success)
+
+    XCTAssertEqual(first, .suppressed)
+    XCTAssertEqual(second, .suppressed)
+    XCTAssertEqual(release, .notSuppressed, "Deferred release runs after the coalesced requests resolve")
+    XCTAssertEqual(fake.endedTokens, [21])
+  }
+
+  func testRequest_concurrentCallsCoalesceOntoOneRequest() {
+    let fake = FakePassLibrary()
+    fake.tokenToReturn = 11
+    let plugin = NfcWalletSuppressionPlugin(library: fake)
+
+    var first: SuppressionStatusCode?
+    var second: SuppressionStatusCode?
+    plugin.requestSuppression { first = (try? $0.get())?.status }
+    plugin.requestSuppression { second = (try? $0.get())?.status }  // in flight -> coalesces
+
+    XCTAssertEqual(fake.requestCount, 1, "A second in-flight request must not issue another PassKit request")
+
+    fake.deliver(.success)
+    XCTAssertEqual(first, .suppressed)
+    XCTAssertEqual(second, .suppressed, "Coalesced request shares the in-flight result")
+  }
+
+  func testRequest_whenAlreadyActiveAndOsAgrees_returnsSuppressedWithoutNewRequest() {
+    let fake = FakePassLibrary()
+    fake.tokenToReturn = 3
+    let plugin = NfcWalletSuppressionPlugin(library: fake)
+
+    plugin.requestSuppression { _ in }
+    fake.deliver(.success)
+    fake.isSuppressingAutomaticPassPresentation = true  // OS confirms still suppressing
+
+    var status: SuppressionStatusCode?
+    plugin.requestSuppression { status = (try? $0.get())?.status }
+
+    XCTAssertEqual(status, .suppressed)
+    XCTAssertEqual(fake.requestCount, 1, "Must not re-request while genuinely active")
+  }
+
+  func testRequest_whenActiveButOsEndedExternally_releasesStaleTokenAndReRequests() {
+    let fake = FakePassLibrary()
+    fake.tokenToReturn = 8
+    let plugin = NfcWalletSuppressionPlugin(library: fake)
+
+    plugin.requestSuppression { _ in }
+    fake.deliver(.success)  // active, token 8
+    fake.isSuppressingAutomaticPassPresentation = false  // OS ended it behind our back
+    fake.tokenToReturn = 9
+
+    var status: SuppressionStatusCode?
+    plugin.requestSuppression { status = (try? $0.get())?.status }
+    XCTAssertEqual(fake.requestCount, 2, "Stale token should trigger a fresh request")
+    XCTAssertTrue(fake.endedTokens.contains(8), "Stale token must be released")
+
+    fake.deliver(.success)
+    XCTAssertEqual(status, .suppressed)
+  }
+
+  // MARK: - releaseSuppression
+
+  func testRelease_fromIdle_returnsUnavailable() {
+    let fake = FakePassLibrary()
+    let plugin = NfcWalletSuppressionPlugin(library: fake)
+
+    var result: SuppressionResult?
+    plugin.releaseSuppression { result = try? $0.get() }
+
+    XCTAssertEqual(result?.status, .unavailable)
+    XCTAssertEqual(result?.message, "No active suppression to release")
+  }
+
+  func testRelease_fromActive_endsTokenAndReportsNotSuppressed() {
+    let fake = FakePassLibrary()
+    fake.tokenToReturn = 5
+    let plugin = NfcWalletSuppressionPlugin(library: fake)
+
+    plugin.requestSuppression { _ in }
+    fake.deliver(.success)
+
+    var status: SuppressionStatusCode?
+    plugin.releaseSuppression { status = (try? $0.get())?.status }
+
+    XCTAssertEqual(fake.endedTokens, [5])
+    XCTAssertEqual(status, .notSuppressed)
+  }
+
+  func testRelease_duringInFlightRequest_isDeferredUntilSuccessThenReleases() {
+    let fake = FakePassLibrary()
+    fake.tokenToReturn = 5
+    let plugin = NfcWalletSuppressionPlugin(library: fake)
+
+    var requestStatus: SuppressionStatusCode?
+    var releaseStatus: SuppressionStatusCode?
+    plugin.requestSuppression { requestStatus = (try? $0.get())?.status }
+    plugin.releaseSuppression { releaseStatus = (try? $0.get())?.status }  // deferred
+
+    XCTAssertTrue(fake.endedTokens.isEmpty, "Release must wait for the in-flight request")
+
+    fake.deliver(.success)
+    XCTAssertEqual(requestStatus, .suppressed)
+    XCTAssertEqual(releaseStatus, .notSuppressed)
+    XCTAssertEqual(fake.endedTokens, [5], "Deferred release ends the now-active token")
+  }
+
+  func testRelease_duringInFlightRequest_whenRequestFails_reportsUnavailable() {
+    let fake = FakePassLibrary()
+    fake.tokenToReturn = 6
+    let plugin = NfcWalletSuppressionPlugin(library: fake)
+
+    var releaseStatus: SuppressionStatusCode?
+    plugin.requestSuppression { _ in }
+    plugin.releaseSuppression { releaseStatus = (try? $0.get())?.status }  // deferred
+
+    fake.deliver(.denied)
+    XCTAssertEqual(releaseStatus, .unavailable, "Nothing to release after a failed request")
+    XCTAssertEqual(fake.endedTokens, [6], "The failed request's token is still released")
+  }
+
+  func testSecondRelease_duringInFlightRequest_returnsUnavailable() {
+    let fake = FakePassLibrary()
+    let plugin = NfcWalletSuppressionPlugin(library: fake)
+
+    plugin.requestSuppression { _ in }
+    plugin.releaseSuppression { _ in }  // first deferred
+
+    var secondRelease: SuppressionStatusCode?
+    plugin.releaseSuppression { secondRelease = (try? $0.get())?.status }
+    XCTAssertEqual(secondRelease, .unavailable)
+  }
+
+  // MARK: - isSuppressed / isSupported
+
+  func testIsSuppressed_reflectsLibraryState() {
+    let fake = FakePassLibrary()
+    fake.isSuppressingAutomaticPassPresentation = true
+    let plugin = NfcWalletSuppressionPlugin(library: fake)
+
+    var suppressed: Bool?
+    plugin.isSuppressed { suppressed = try? $0.get() }
+    XCTAssertEqual(suppressed, true)
+  }
+
+  func testIsSupported_reflectsPassLibraryAvailability() {
+    let fake = FakePassLibrary()
+    fake.isPassLibraryAvailable = true
+    let plugin = NfcWalletSuppressionPlugin(library: fake)
+
+    var supported: Bool?
+    plugin.isSupported { supported = try? $0.get() }
+    XCTAssertEqual(supported, true)
+  }
 }

--- a/ios/nfc_wallet_suppression/Sources/nfc_wallet_suppression/NfcWalletSuppressionPlugin.swift
+++ b/ios/nfc_wallet_suppression/Sources/nfc_wallet_suppression/NfcWalletSuppressionPlugin.swift
@@ -2,6 +2,58 @@ import Flutter
 import UIKit
 import PassKit
 
+/// Abstraction over the PassKit automatic-pass-presentation suppression APIs.
+///
+/// PassKit exposes these as static functions on `PKPassLibrary`, which makes the
+/// suppression logic impossible to unit test. Routing every call through this
+/// protocol lets the plugin be driven by a fake in tests while using the real
+/// system implementation in production.
+///
+/// Implementations MUST invoke the request response handler on the main thread,
+/// and asynchronously (after `requestSuppression` has returned) — see
+/// `SystemPassLibrary`. The plugin relies on both: state is touched only on the
+/// main thread, and the token returned by `requestSuppression` is recorded
+/// before the handler runs.
+protocol PassPresentationSuppressing {
+  var isPassLibraryAvailable: Bool { get }
+  var isSuppressingAutomaticPassPresentation: Bool { get }
+
+  /// Requests suppression. Returns the request token, or `0` when the request
+  /// could not be submitted (in which case the response handler is not called).
+  func requestSuppression(
+    responseHandler: @escaping (PKAutomaticPassPresentationSuppressionResult) -> Void
+  ) -> PKSuppressionRequestToken
+
+  func endSuppression(withRequestToken token: PKSuppressionRequestToken)
+}
+
+/// Production implementation backed by `PKPassLibrary`.
+struct SystemPassLibrary: PassPresentationSuppressing {
+  var isPassLibraryAvailable: Bool { PKPassLibrary.isPassLibraryAvailable() }
+
+  var isSuppressingAutomaticPassPresentation: Bool {
+    PKPassLibrary.isSuppressingAutomaticPassPresentation()
+  }
+
+  func requestSuppression(
+    responseHandler: @escaping (PKAutomaticPassPresentationSuppressionResult) -> Void
+  ) -> PKSuppressionRequestToken {
+    // PassKit does not annotate this API for concurrency and may invoke the
+    // response handler on an arbitrary (background) thread. Hop back to the
+    // main thread so the plugin's state stays single-threaded and the pigeon
+    // reply is delivered on the platform thread.
+    // https://developer.apple.com/documentation/passkit/pkpasslibrary/requestautomaticpasspresentationsuppression(responsehandler:)
+    PKPassLibrary.requestAutomaticPassPresentationSuppression { result in
+      DispatchQueue.main.async { responseHandler(result) }
+    }
+  }
+
+  func endSuppression(withRequestToken token: PKSuppressionRequestToken) {
+    // https://developer.apple.com/documentation/passkit/pkpasslibrary/endautomaticpasspresentationsuppression(withrequesttoken:)
+    PKPassLibrary.endAutomaticPassPresentationSuppression(withRequestToken: token)
+  }
+}
+
 public class NfcWalletSuppressionPlugin: NSObject, FlutterPlugin, NfcWalletSuppressionApi {
   public static func register(with registrar: FlutterPluginRegistrar) {
     let messenger = registrar.messenger()
@@ -9,116 +61,168 @@ public class NfcWalletSuppressionPlugin: NSObject, FlutterPlugin, NfcWalletSuppr
     NfcWalletSuppressionApiSetup.setUp(binaryMessenger: messenger, api: api)
   }
 
-  private var suppressionToken: PKSuppressionRequestToken?
+  typealias Completion = (Result<SuppressionResult, Error>) -> Void
 
-  func requestSuppression(completion: @escaping (Result<SuppressionResult, Error>) -> Void) {
-    // Release any existing token to prevent race conditions and memory leaks
-    if let existingToken = suppressionToken {
-      #if DEBUG
-      NSLog("[NFC Wallet Suppression] Releasing existing token before new request")
-      #endif
-      PKPassLibrary.endAutomaticPassPresentationSuppression(withRequestToken: existingToken)
-      suppressionToken = nil
-    }
-    
-    //https://developer.apple.com/documentation/passkit/pkpasslibrary/requestautomaticpasspresentationsuppression(responsehandler:)
-    self.suppressionToken = PKPassLibrary.requestAutomaticPassPresentationSuppression(
-      responseHandler: { requestResult in
-        let result: SuppressionResult
-        //https://developer.apple.com/documentation/passkit/pkautomaticpasspresentationsuppressionresult
-        switch requestResult {
-        case .success:
-          #if DEBUG
-          NSLog("[NFC Wallet Suppression] Request success: Pass presentation suppressed")
-          #endif
-          result = SuppressionResult(
-            status: .suppressed,
-            message: "Automatic pass presentation is suppressed."
-          )
-        case .notSupported:
-          #if DEBUG
-          NSLog("[NFC Wallet Suppression] Request failed: Not supported")
-          #endif
-          result = SuppressionResult(
-            status: .notSupported,
-            message: "Device does not support automatic pass presentation suppression."
-          )
-        case .alreadyPresenting:
-          #if DEBUG
-          NSLog("[NFC Wallet Suppression] Request failed: Already presenting")
-          #endif
-          result = SuppressionResult(
-            status: .alreadyPresenting,
-            message: "Wallet is already presenting a pass."
-          )
-        case .cancelled:
-          #if DEBUG
-          NSLog("[NFC Wallet Suppression] Request cancelled")
-          #endif
-          result = SuppressionResult(
-            status: .cancelled,
-            message: "Suppression request was cancelled."
-          )
-        case .denied:
-          #if DEBUG
-          NSLog("[NFC Wallet Suppression] Request denied")
-          #endif
-          result = SuppressionResult(
-            status: .denied,
-            message: "Suppression request was denied by the user or system."
-          )
-        @unknown default:
-          #if DEBUG
-          NSLog("[NFC Wallet Suppression] Request failed: Unknown result")
-          #endif
-          result = SuppressionResult(
-            status: .unknown,
-            message: "Unknown error occurred during suppression request."
-          )
-        }
-        completion(.success(result))
-      }
-    )
+  private let library: PassPresentationSuppressing
+
+  // MARK: Lifecycle state
+  //
+  // Modelled as an enum so illegal combinations are unrepresentable. All access
+  // is confined to the main thread: pigeon dispatches the API methods there, and
+  // `SystemPassLibrary` delivers the PassKit callback there too, so no locking is
+  // required.
+  private enum State {
+    /// No suppression and no request in flight.
+    case idle
+    /// A PassKit request is in flight. `waiters` are coalesced request
+    /// completions; `release` is a release awaiting the result; `token` is the
+    /// issued token (`nil` until known, or if the request could not be submitted).
+    case inFlight(waiters: [Completion], release: Completion?, token: PKSuppressionRequestToken?)
+    /// Suppression is active, holding `token`.
+    case active(PKSuppressionRequestToken)
+  }
+  private var state: State = .idle
+
+  init(library: PassPresentationSuppressing = SystemPassLibrary()) {
+    self.library = library
+    super.init()
   }
 
-  //https://developer.apple.com/documentation/passkit/pkpasslibrary/endautomaticpasspresentationsuppression(withrequesttoken:)
-  func releaseSuppression(completion: @escaping (Result<SuppressionResult, Error>) -> Void) {
-    guard let token = suppressionToken else {
-      let result = SuppressionResult(
-        status: .unavailable,
-        message: "No active suppression to release"
-      )
-      completion(.success(result))
+  private enum Message {
+    static let suppressed = "Automatic pass presentation is suppressed."
+    static let alreadySuppressed = "Automatic pass presentation is already suppressed."
+    static let notSupported = "Device does not support automatic pass presentation suppression."
+    static let alreadyPresenting = "Wallet is already presenting a pass."
+    static let cancelled = "Suppression request was cancelled."
+    static let denied = "Suppression request was denied by the user or system."
+    static let unknown = "Unknown error occurred during suppression request."
+    static let couldNotSubmit = "Suppression request could not be submitted."
+    static let released = "Suppression released"
+    static let noActiveToRelease = "No active suppression to release"
+  }
+
+  /// Maps a PassKit suppression result to the cross-platform pigeon result.
+  ///
+  /// Pure and side-effect free so the mapping can be unit tested directly.
+  /// https://developer.apple.com/documentation/passkit/pkautomaticpasspresentationsuppressionresult
+  static func suppressionResult(
+    for result: PKAutomaticPassPresentationSuppressionResult
+  ) -> SuppressionResult {
+    switch result {
+    case .success:
+      return SuppressionResult(status: .suppressed, message: Message.suppressed)
+    case .notSupported:
+      return SuppressionResult(status: .notSupported, message: Message.notSupported)
+    case .alreadyPresenting:
+      return SuppressionResult(status: .alreadyPresenting, message: Message.alreadyPresenting)
+    case .cancelled:
+      return SuppressionResult(status: .cancelled, message: Message.cancelled)
+    case .denied:
+      return SuppressionResult(status: .denied, message: Message.denied)
+    @unknown default:
+      return SuppressionResult(status: .unknown, message: Message.unknown)
+    }
+  }
+
+  func requestSuppression(completion: @escaping Completion) {
+    switch state {
+    case .active(let token):
+      // Confirm the OS still agrees before reporting success.
+      if library.isSuppressingAutomaticPassPresentation {
+        completion(.success(SuppressionResult(status: .suppressed, message: Message.alreadySuppressed)))
+      } else {
+        // Stale token: suppression was ended outside the plugin. Drop it and
+        // issue a fresh request.
+        library.endSuppression(withRequestToken: token)
+        state = .idle
+        startRequest(completion)
+      }
+    case .inFlight(let waiters, let release, let token):
+      // Coalesce onto the in-flight request rather than issuing a second one.
+      state = .inFlight(waiters: waiters + [completion], release: release, token: token)
+    case .idle:
+      startRequest(completion)
+    }
+  }
+
+  /// Issues a new PassKit request. Precondition: `state == .idle`.
+  private func startRequest(_ completion: @escaping Completion) {
+    state = .inFlight(waiters: [completion], release: nil, token: nil)
+    let token = library.requestSuppression { [weak self] passResult in
+      // Delivered on the main thread by `SystemPassLibrary`, after this method
+      // has returned and the token has been recorded below.
+      self?.resolveInFlight(passResult)
+    }
+    // Record the issued token in the in-flight state for the handler to use.
+    if case .inFlight(let waiters, let release, _) = state {
+      state = .inFlight(waiters: waiters, release: release, token: token == 0 ? nil : token)
+    }
+    if token == 0 {
+      // The request could not be submitted; the handler will not fire.
+      resolveInFlight(nil)
+    }
+  }
+
+  /// Resolves the in-flight request. `passResult == nil` means the request could
+  /// not be submitted (a `0` token).
+  private func resolveInFlight(_ passResult: PKAutomaticPassPresentationSuppressionResult?) {
+    guard case .inFlight(let waiters, let release, let token) = state else { return }
+
+    let result: SuppressionResult
+    if let passResult = passResult, let token = token {
+      result = NfcWalletSuppressionPlugin.suppressionResult(for: passResult)
+      if passResult == .success {
+        state = .active(token)
+      } else {
+        // Failed: release the issued token so it cannot leak.
+        library.endSuppression(withRequestToken: token)
+        state = .idle
+      }
+    } else {
+      // No token: the request could not be submitted (or a token-less result,
+      // which is anomalous). Either way nothing is held.
+      if let token = token { library.endSuppression(withRequestToken: token) }
+      result = SuppressionResult(status: .unknown, message: Message.couldNotSubmit)
+      state = .idle
+    }
+
+    // State and the captured `release` are settled before firing completions, so
+    // the order is correct regardless of what callers do on completion.
+    waiters.forEach { $0(.success(result)) }
+    if let release = release {
+      performRelease(release)
+    }
+  }
+
+  func releaseSuppression(completion: @escaping Completion) {
+    switch state {
+    case .inFlight(let waiters, let release, let token):
+      if release != nil {
+        // A release is already queued behind the in-flight request.
+        completion(.success(SuppressionResult(status: .unavailable, message: Message.noActiveToRelease)))
+      } else {
+        state = .inFlight(waiters: waiters, release: completion, token: token)
+      }
+    case .active, .idle:
+      performRelease(completion)
+    }
+  }
+
+  private func performRelease(_ completion: @escaping Completion) {
+    guard case .active(let token) = state else {
+      completion(.success(SuppressionResult(status: .unavailable, message: Message.noActiveToRelease)))
       return
     }
-    
-    PKPassLibrary.endAutomaticPassPresentationSuppression(withRequestToken: token)
-    suppressionToken = nil
-    
-    #if DEBUG
-    NSLog("[NFC Wallet Suppression] Automatic pass presentation enabled")
-    #endif
-    
-    let result = SuppressionResult(
-      status: .notSuppressed,
-      message: "Suppression released"
-    )
-    completion(.success(result))
+    library.endSuppression(withRequestToken: token)
+    state = .idle
+    completion(.success(SuppressionResult(status: .notSuppressed, message: Message.released)))
   }
 
   func isSuppressed(completion: @escaping (Result<Bool, Error>) -> Void) {
-    let suppressed = PKPassLibrary.isSuppressingAutomaticPassPresentation()
-    completion(.success(suppressed))
+    completion(.success(library.isSuppressingAutomaticPassPresentation))
   }
 
   func isSupported(completion: @escaping (Result<Bool, Error>) -> Void) {
-    // Check iOS version (requires iOS 13.0+) and PassKit library availability
-    if #available(iOS 13.0, *) {
-      // isPassLibraryAvailable() checks if the device supports PassKit (e.g. has Secure Element)
-      // This is a robust check for NFC/Apple Pay capability
-      completion(.success(PKPassLibrary.isPassLibraryAvailable()))
-    } else {
-      completion(.success(false))
-    }
+    completion(.success(library.isPassLibraryAvailable))
   }
 }

--- a/ios/nfc_wallet_suppression/Sources/nfc_wallet_suppression/NfcWalletSuppressionPlugin.swift
+++ b/ios/nfc_wallet_suppression/Sources/nfc_wallet_suppression/NfcWalletSuppressionPlugin.swift
@@ -9,8 +9,8 @@ import PassKit
 /// protocol lets the plugin be driven by a fake in tests while using the real
 /// system implementation in production.
 ///
-/// Implementations MUST invoke the request response handler on the main thread,
-/// and asynchronously (after `requestSuppression` has returned) — see
+/// Implementations MUST invoke the response handler on the main thread, and
+/// asynchronously (after `requestSuppression` has returned) — see
 /// `SystemPassLibrary`. The plugin relies on both: state is touched only on the
 /// main thread, and the token returned by `requestSuppression` is recorded
 /// before the handler runs.
@@ -75,8 +75,9 @@ public class NfcWalletSuppressionPlugin: NSObject, FlutterPlugin, NfcWalletSuppr
     /// No suppression and no request in flight.
     case idle
     /// A PassKit request is in flight. `waiters` are coalesced request
-    /// completions; `release` is a release awaiting the result; `token` is the
-    /// issued token (`nil` until known, or if the request could not be submitted).
+    /// completions; `release` is a release completion awaiting the result;
+    /// `token` is the issued token (`nil` until known, or if the request could
+    /// not be submitted).
     case inFlight(waiters: [Completion], release: Completion?, token: PKSuppressionRequestToken?)
     /// Suppression is active, holding `token`.
     case active(PKSuppressionRequestToken)
@@ -180,7 +181,7 @@ public class NfcWalletSuppressionPlugin: NSObject, FlutterPlugin, NfcWalletSuppr
       }
     } else {
       // No token: the request could not be submitted (or a token-less result,
-      // which is anomalous). Either way nothing is held.
+      // which is anomalous). Either way, nothing is held.
       if let token = token { library.endSuppression(withRequestToken: token) }
       result = SuppressionResult(status: .unknown, message: Message.couldNotSubmit)
       state = .idle
@@ -209,6 +210,11 @@ public class NfcWalletSuppressionPlugin: NSObject, FlutterPlugin, NfcWalletSuppr
   }
 
   private func performRelease(_ completion: @escaping Completion) {
+    // Intent-based release (matches Android): if we hold a token, we release it
+    // and report .notSuppressed; otherwise .unavailable. We deliberately do not
+    // reconcile against isSuppressingAutomaticPassPresentation here so the
+    // request/release pair stays clean and both platforms behave identically;
+    // isSuppressed reports live state.
     guard case .active(let token) = state else {
       completion(.success(SuppressionResult(status: .unavailable, message: Message.noActiveToRelease)))
       return
@@ -222,6 +228,11 @@ public class NfcWalletSuppressionPlugin: NSObject, FlutterPlugin, NfcWalletSuppr
     completion(.success(library.isSuppressingAutomaticPassPresentation))
   }
 
+  /// Reports whether the Wallet pass library is available, which is a *necessary*
+  /// condition for suppression (e.g. it is false on iPad). It is not a guarantee
+  /// that a suppression request will succeed — PassKit exposes no API to query
+  /// suppression capability or the required entitlement up front. The definitive
+  /// answer comes from `requestSuppression`'s result (`.notSupported` / `.denied`).
   func isSupported(completion: @escaping (Result<Bool, Error>) -> Void) {
     completion(.success(library.isPassLibraryAvailable))
   }

--- a/lib/src/nfc_wallet_suppression.dart
+++ b/lib/src/nfc_wallet_suppression.dart
@@ -54,18 +54,30 @@ class NfcWalletSuppression {
   /// **Important:** On iOS, this may prompt the user for permission. Rapid or
   /// overlapping calls are safe: on both platforms a call made while suppression
   /// is already active returns [SuppressionStatus.suppressed] without re-arming.
-  /// On iOS, concurrent calls made while a request is in flight share that
-  /// request's result.
+  /// On iOS, overlapping (un-awaited) calls made while a request is in flight
+  /// share that request's result.
+  ///
+  /// **Serialize your calls:** `await` each [requestSuppression] or
+  /// [releaseSuppression] before issuing the next. Interleaving them without
+  /// awaiting (e.g., request, then release, then request) is resolved
+  /// best-effort — the resulting suppression state is not guaranteed and may
+  /// differ between platforms. For sequential (awaited) use, the two platforms
+  /// behave identically. Query [isSuppressed] for the live state.
   ///
   /// ## Returns
   ///
   /// A [Future] that completes with a [SuppressionStatus]:
-  /// - [SuppressionStatus.suppressed]: Successfully suppressed wallet
-  /// - [SuppressionStatus.denied]: User denied permission (iOS only)
-  /// - [SuppressionStatus.cancelled]: User cancelled the permission prompt (iOS)
-  /// - [SuppressionStatus.notSupported]: Device doesn't support suppression
-  /// - [SuppressionStatus.alreadyPresenting]: Wallet is already active (iOS)
-  /// - [SuppressionStatus.unavailable]: NFC hardware not available
+  /// - [SuppressionStatus.suppressed]: Suppression is active
+  /// - [SuppressionStatus.notSupported]: Suppression isn't supported — Android:
+  ///   the device has no NFC hardware; iOS: PassKit reports it unsupported
+  /// - [SuppressionStatus.unavailable]: Temporarily unavailable and recoverable
+  ///   (Android only) — NFC is turned off, or no activity is attached
+  /// - [SuppressionStatus.denied]: Permission denied — iOS: by the user or
+  ///   system; Android: a `SecurityException` on the NFC call
+  /// - [SuppressionStatus.alreadyPresenting]: Wallet is already presenting a pass
+  ///   (iOS only)
+  /// - [SuppressionStatus.cancelled]: User cancelled the permission prompt
+  ///   (iOS only)
   /// - [SuppressionStatus.unknown]: An unexpected error occurred
   ///
   /// ## Platform Behavior
@@ -119,21 +131,35 @@ class NfcWalletSuppression {
   /// ## Returns
   ///
   /// A [Future] that completes with a [SuppressionStatus]:
-  /// - [SuppressionStatus.notSuppressed]: Successfully released suppression
-  /// - [SuppressionStatus.unavailable]: No active suppression to release
-  /// - [SuppressionStatus.unknown]: An unexpected error occurred
+  /// - [SuppressionStatus.notSuppressed]: The suppression you requested has been
+  ///   released
+  /// - [SuppressionStatus.unavailable]: There was no suppression to release
+  ///   (none was requested, or it was already released)
+  /// - [SuppressionStatus.denied]: Android — tearing down reader mode failed
+  ///   with a `SecurityException`; suppression may still be active
+  /// - [SuppressionStatus.unknown]: An unexpected error occurred (an Android
+  ///   reader-mode tear-down failure, or a platform-channel failure);
+  ///   suppression may still be active
+  ///
+  /// Release is based on the suppression you requested, not on live device
+  /// state: it returns [SuppressionStatus.notSuppressed] even if suppression had
+  /// already lapsed in the meantime (e.g. the app was backgrounded or the user
+  /// turned NFC off). Use [isSuppressed] to query whether suppression is
+  /// actually in effect right now. Both platforms behave identically here.
   ///
   /// ## Platform Behavior
   ///
   /// **iOS:**
   /// - Uses PassKit's `endAutomaticPassPresentationSuppression`
   /// - Safe to call even if suppression was never requested
-  /// - Returns [SuppressionStatus.unavailable] if no suppression is active
+  /// - Returns [SuppressionStatus.unavailable] if no suppression was requested
+  ///   (or it was already released)
   ///
   /// **Android:**
   /// - Disables NFC reader mode
   /// - Safe to call even if suppression was never requested
-  /// - Returns [SuppressionStatus.unavailable] if no suppression is active
+  /// - Returns [SuppressionStatus.unavailable] if no suppression was requested
+  ///   (or it was already released)
   ///
   /// ## Example
   ///
@@ -175,7 +201,7 @@ class NfcWalletSuppression {
   /// **Android:**
   /// - Returns `true` only while suppression is active, an activity is attached,
   ///   and NFC is still enabled
-  /// - Suppression is re-armed across activity recreation (e.g. screen rotation)
+  /// - Suppression is re-armed across activity recreation (e.g., screen rotation)
   /// - Returns `false` if the activity is detached or NFC was turned off
   ///
   /// ## Example
@@ -208,6 +234,12 @@ class NfcWalletSuppression {
   /// - Requires iOS 13.0 or later
   /// - Requires iPhone 7 or later (NFC hardware)
   /// - Requires the PassKit entitlement
+  ///
+  /// Note: on iOS this reflects Wallet pass-library availability — a *necessary*
+  /// condition, not a guarantee that suppression will succeed (PassKit exposes no
+  /// API to query suppression capability or the entitlement up front). A `true`
+  /// result can still be followed by [SuppressionStatus.notSupported] or
+  /// [SuppressionStatus.denied] from [requestSuppression].
   ///
   /// **Android:**
   /// - Requires Android 5.0+ (API 21)

--- a/lib/src/nfc_wallet_suppression.dart
+++ b/lib/src/nfc_wallet_suppression.dart
@@ -51,10 +51,11 @@ class NfcWalletSuppression {
   /// This allows your app to read NFC tags without competition from the
   /// system wallet.
   ///
-  /// **Important:** On iOS, this may prompt the user for permission. Rapid
-  /// repeat calls are safe: on iOS the plugin releases any existing
-  /// suppression token before requesting a new one; on Android the framework
-  /// replaces the previous reader-mode/foreground-dispatch registration.
+  /// **Important:** On iOS, this may prompt the user for permission. Rapid or
+  /// overlapping calls are safe: on both platforms a call made while suppression
+  /// is already active returns [SuppressionStatus.suppressed] without re-arming.
+  /// On iOS, concurrent calls made while a request is in flight share that
+  /// request's result.
   ///
   /// ## Returns
   ///
@@ -76,7 +77,8 @@ class NfcWalletSuppression {
   /// - Survives configuration changes (screen rotation)
   ///
   /// **Android:**
-  /// - Uses NFC Adapter's `enableReaderMode` and `enableForegroundDispatch`
+  /// - Uses the NFC Adapter's reader mode (`enableReaderMode`), which takes over
+  ///   the NFC stack and suppresses wallet / host-card-emulation apps
   /// - No permission prompt required
   /// - Automatically restored after activity recreation
   /// - Requires NFC to be enabled in device settings
@@ -126,12 +128,12 @@ class NfcWalletSuppression {
   /// **iOS:**
   /// - Uses PassKit's `endAutomaticPassPresentationSuppression`
   /// - Safe to call even if suppression was never requested
-  /// - Returns [SuppressionStatus.unavailable] if no token exists
+  /// - Returns [SuppressionStatus.unavailable] if no suppression is active
   ///
   /// **Android:**
-  /// - Disables NFC reader mode and foreground dispatch
+  /// - Disables NFC reader mode
   /// - Safe to call even if suppression was never requested
-  /// - Returns [SuppressionStatus.notSuppressed] if NFC is disabled or absent
+  /// - Returns [SuppressionStatus.unavailable] if no suppression is active
   ///
   /// ## Example
   ///
@@ -171,9 +173,10 @@ class NfcWalletSuppression {
   /// - Accurately reflects system-wide suppression state
   ///
   /// **Android:**
-  /// - Tracks suppression state internally
-  /// - State persists across activity recreation (e.g., screen rotation)
-  /// - Returns `false` if activity is detached
+  /// - Returns `true` only while suppression is active, an activity is attached,
+  ///   and NFC is still enabled
+  /// - Suppression is re-armed across activity recreation (e.g. screen rotation)
+  /// - Returns `false` if the activity is detached or NFC was turned off
   ///
   /// ## Example
   ///

--- a/test/nfc_wallet_suppression_pigeon_impl_test.dart
+++ b/test/nfc_wallet_suppression_pigeon_impl_test.dart
@@ -402,26 +402,6 @@ void main() {
         expect(results[2], SuppressionStatus.notSuppressed);
         expect(results[3], true);
       });
-
-      test('state changes do not affect pending operations', () async {
-        mockApi.mockRequestResult = SuppressionResult(
-          status: SuppressionStatusCode.suppressed,
-          message: 'Success',
-        );
-
-        // Start operation
-        final future = platform.requestSuppression();
-
-        // Change mock state
-        mockApi.mockRequestResult = SuppressionResult(
-          status: SuppressionStatusCode.unknown,
-          message: 'Changed',
-        );
-
-        // Original operation should complete with original result
-        final result = await future;
-        expect(result, SuppressionStatus.suppressed);
-      });
     });
 
     group('default instance', () {

--- a/test/nfc_wallet_suppression_status_test.dart
+++ b/test/nfc_wallet_suppression_status_test.dart
@@ -23,59 +23,5 @@ void main() {
       );
       expect(SuppressionStatus.values, contains(SuppressionStatus.unknown));
     });
-
-    test('enum values have correct names', () {
-      expect(SuppressionStatus.notSuppressed.name, 'notSuppressed');
-      expect(SuppressionStatus.suppressed.name, 'suppressed');
-      expect(SuppressionStatus.unavailable.name, 'unavailable');
-      expect(SuppressionStatus.denied.name, 'denied');
-      expect(SuppressionStatus.cancelled.name, 'cancelled');
-      expect(SuppressionStatus.notSupported.name, 'notSupported');
-      expect(SuppressionStatus.alreadyPresenting.name, 'alreadyPresenting');
-      expect(SuppressionStatus.unknown.name, 'unknown');
-    });
-
-    test('enum values are distinct', () {
-      final values = SuppressionStatus.values.toSet();
-      expect(values.length, SuppressionStatus.values.length);
-    });
-
-    test('enum can be compared for equality', () {
-      expect(
-        SuppressionStatus.suppressed == SuppressionStatus.suppressed,
-        isTrue,
-      );
-      expect(
-        SuppressionStatus.suppressed == SuppressionStatus.notSuppressed,
-        isFalse,
-      );
-    });
-
-    test('enum can be used in switch statements', () {
-      String getDescription(SuppressionStatus status) {
-        switch (status) {
-          case SuppressionStatus.notSuppressed:
-            return 'not suppressed';
-          case SuppressionStatus.suppressed:
-            return 'suppressed';
-          case SuppressionStatus.unavailable:
-            return 'unavailable';
-          case SuppressionStatus.denied:
-            return 'denied';
-          case SuppressionStatus.cancelled:
-            return 'cancelled';
-          case SuppressionStatus.notSupported:
-            return 'not supported';
-          case SuppressionStatus.alreadyPresenting:
-            return 'already presenting';
-          case SuppressionStatus.unknown:
-            return 'unknown';
-        }
-      }
-
-      expect(getDescription(SuppressionStatus.suppressed), 'suppressed');
-      expect(getDescription(SuppressionStatus.notSupported), 'not supported');
-      expect(getDescription(SuppressionStatus.unknown), 'unknown');
-    });
   });
 }


### PR DESCRIPTION
Reworks the iOS and Android NFC-wallet-suppression plugins around one correct,
testable lifecycle design, and hardens the CI/branch-protection setup. Found via
multiple code-review passes; every fix is researched and locally verified.

## Native lifecycle (commit 1)

Both platforms had real lifecycle/threading bugs and almost no native test
coverage. Rework both behind a small seam over the platform APIs (testability)
with an explicit, in-sync lifecycle.

**iOS** (`NfcWalletSuppressionPlugin.swift`)
- `SystemPassLibrary` hops PassKit's callback to the main thread (PassKit may
  deliver it on an arbitrary thread per Apple DTS; pigeon runs on main).
- 3-case enum state machine (`idle`/`inFlight`/`active`) → illegal states
  unrepresentable: concurrent requests coalesce, a release waits for the in-flight
  request, every completion fires exactly once, and the `NSUInteger` token (0 =
  none) is never stored as live.
- Reconcile a stale active token against live system state; release a token issued
  for a failed request; map a missing/0 token to `.unknown`.

**Android** (`NfcWalletSuppressionPlugin.kt`)
- Drop `enableForegroundDispatch` (reader mode alone suppresses wallet/HCE; the
  two conflict); add `FLAG_READER_NO_PLATFORM_SOUNDS`.
- Route `NfcAdapter` through a `WalletSuppressor` seam (unit testable).
- Fix state desync: re-arm reader mode on (re)attach, reconcile `isSuppressed()`
  against attached-activity + NFC-enabled, short-circuit already-active requests
  (parity with iOS), align release with iOS (`UNAVAILABLE` when nothing active).

**Tests:** 15 iOS + 15 Android tests now drive the real suppression/release/
lifecycle paths through fakes. Verified locally: iOS `xcodebuild test` 15/15
(Xcode 26.5, iPhone 17 Pro), Android `gradlew testDebugUnitTest` 15/15,
`flutter analyze` clean, 79 Dart tests.

## CI / branch protection (commit 2)

- Add a single **`CI Success`** gate job that depends on every job and fails if
  any failed/was cancelled (skipped path-filtered jobs are OK). The branch
  ruleset now requires only `CI Success`, so protection no longer references
  brittle matrix-expanded check names (GitHub-recommended pattern).
- **Remove `paths-ignore`** so the workflow — and thus the required gate — always
  reports (a path-skipped workflow would leave PRs stuck "waiting"). Slow
  native/build jobs still skip per-job via `check_changes`.
- Run `publish-dry-run` + `pana` on pushes to the default branch too.
- Docs: `isSupported` documents that it reflects Wallet pass-library availability
  (necessary, not sufficient); drop stale `unknown` from `releaseSuppression`.
- Remove tautological/mistargeted tests.

## Notes
- Branch protection was updated to require `CI Success`; this PR is the first to
  exercise it end-to-end.
- Deferred (not in scope): Android event-channel for spontaneous suppression
  loss; multi-activity double reader-mode session; README wording.