### PR TITLE
fix(testing): track FakeNfcWalletSuppression suppressed state by outcome

### DIFF
--- a/lib/src/nfc_wallet_suppression_testing.dart
+++ b/lib/src/nfc_wallet_suppression_testing.dart
@@ -59,7 +59,11 @@ class FakeNfcWalletSuppression extends NfcWalletSuppressionPlatform {
     _releaseResult = result;
   }
 
-  /// Manually set the suppressed state (simulates external state change)
+  /// Manually set the suppressed state (simulates an external state change).
+  ///
+  /// Note: a subsequent [requestSuppression] or [releaseSuppression] call
+  /// updates this flag based on that call's configured result, so this override
+  /// reflects state only until the next request/release.
   void setSuppressed(bool suppressed) {
     _isCurrentlySuppressed = suppressed;
   }
@@ -82,16 +86,22 @@ class FakeNfcWalletSuppression extends NfcWalletSuppressionPlatform {
   @override
   Future<SuppressionStatus> requestSuppression() async {
     methodCalls.add('requestSuppression');
-    if (_requestResult == SuppressionStatus.suppressed) {
-      _isCurrentlySuppressed = true;
-    }
+    // Suppression is active only when the request reports success; any other
+    // outcome leaves it inactive. Assigning (rather than only setting `true`)
+    // prevents a stale `true` from surviving a later failed request.
+    _isCurrentlySuppressed = _requestResult == SuppressionStatus.suppressed;
     return _requestResult;
   }
 
   @override
   Future<SuppressionStatus> releaseSuppression() async {
     methodCalls.add('releaseSuppression');
-    if (_releaseResult == SuppressionStatus.notSuppressed) {
+    // `notSuppressed` (released) and `unavailable` (nothing to release) both mean
+    // suppression is no longer active. A failure result (e.g., `denied` or
+    // `unknown`) means the release did not take effect, so the prior state is
+    // preserved.
+    if (_releaseResult == SuppressionStatus.notSuppressed ||
+        _releaseResult == SuppressionStatus.unavailable) {
       _isCurrentlySuppressed = false;
     }
     return _releaseResult;

--- a/test/nfc_wallet_suppression_testing_test.dart
+++ b/test/nfc_wallet_suppression_testing_test.dart
@@ -78,6 +78,39 @@ void main() {
       expect(status, SuppressionStatus.unknown);
     });
 
+    test('a failed request clears a previously suppressed state', () async {
+      fake.setRequestResult(SuppressionStatus.suppressed);
+      await NfcWalletSuppression.requestSuppression();
+      expect(await NfcWalletSuppression.isSuppressed(), true);
+
+      // A later request that fails must not leave a stale `true`.
+      fake.setRequestResult(SuppressionStatus.denied);
+      await NfcWalletSuppression.requestSuppression();
+      expect(await NfcWalletSuppression.isSuppressed(), false);
+    });
+
+    test('a failed release keeps suppression active', () async {
+      fake.setRequestResult(SuppressionStatus.suppressed);
+      await NfcWalletSuppression.requestSuppression();
+
+      fake.setReleaseResult(SuppressionStatus.unknown);
+      await NfcWalletSuppression.releaseSuppression();
+      expect(
+        await NfcWalletSuppression.isSuppressed(),
+        true,
+        reason: 'A failed release must not clear suppression',
+      );
+    });
+
+    test('release returning unavailable clears suppression', () async {
+      fake.setRequestResult(SuppressionStatus.suppressed);
+      await NfcWalletSuppression.requestSuppression();
+
+      fake.setReleaseResult(SuppressionStatus.unavailable);
+      await NfcWalletSuppression.releaseSuppression();
+      expect(await NfcWalletSuppression.isSuppressed(), false);
+    });
+
     test('reset clears state and call history', () async {
       fake.setSupported(false);
       fake.setRequestResult(SuppressionStatus.unavailable);


### PR DESCRIPTION
Follow-up to #35. Fixes the one remaining real (low-severity) finding from the
review of the suppression-lifecycle work: a stale-state bug in the **shipped**
testing helper (`package:nfc_wallet_suppression/testing.dart`).

## Problem
`FakeNfcWalletSuppression` only updated its internal `_isCurrentlySuppressed`
flag for the canonical results:
- `requestSuppression` set it `true` only when the result was `suppressed`
- `releaseSuppression` cleared it only when the result was `notSuppressed`

Any other configured result left the flag **stale**, so a consumer's
`isSuppressed()` could report a value inconsistent with the lifecycle they
configured (e.g. request `suppressed` then release `unavailable` left
`isSuppressed()` stuck `true`).

## Fix
Track the flag by the operation's outcome, mirroring the real plugin lifecycle:
- **requestSuppression:** suppressed **iff** the result is `suppressed` — a failed
  request no longer leaves a stale `true`.
- **releaseSuppression:** cleared on `notSuppressed` **or** `unavailable` (both mean
  "not suppressed now"); a failure result (`denied`/`unknown`) preserves the prior
  state, since the release didn't take effect.

Adds tests for the failed-request, failed-release, and release-unavailable paths.

## Verification
`dart format` clean, `flutter analyze` clean, 82 Dart tests pass (Dart-only change).