### PR TITLE
ci: enforce pana score gate (>=130) on PRs, aligned with release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -475,17 +475,26 @@ jobs:
       
       - name: Run pana
         run: |
-          dart pub global run pana --no-warning | tee pana-output.txt
-          SCORE=$(grep -o 'Score: [0-9]*' pana-output.txt | grep -o '[0-9]*' | tail -1 || echo "0")
-          echo "## 🎯 Pana Score: ${SCORE}/160" >> $GITHUB_STEP_SUMMARY
+          # Enforce the same threshold the release gate uses (publish.yml) so a
+          # release-blocking pub-score regression fails here on the PR, not later
+          # at tag time.
+          set +e
+          dart pub global run pana --no-warning --exit-code-threshold 130 | tee pana-output.txt
+          PANA_EXIT=${PIPESTATUS[0]}
+          set -e
+          # For the summary only; the pass/fail decision is PANA_EXIT above. Show
+          # "unknown" (not a misleading 0) if pana's output format ever changes.
+          SCORE=$(grep -o 'Score: [0-9]*' pana-output.txt | grep -o '[0-9]*' | tail -1)
+          echo "## 🎯 Pana Score: ${SCORE:-unknown}/160 (required: >= 130)" >> $GITHUB_STEP_SUMMARY
           echo '```' >> $GITHUB_STEP_SUMMARY
           cat pana-output.txt >> $GITHUB_STEP_SUMMARY
           echo '```' >> $GITHUB_STEP_SUMMARY
-          if [ "$SCORE" -lt 130 ]; then
-            echo "⚠️ Score is below recommended threshold of 130" >> $GITHUB_STEP_SUMMARY
+          if [ "$PANA_EXIT" -ne 0 ]; then
+            echo "❌ Score is below the required threshold of 130/160" >> $GITHUB_STEP_SUMMARY
           else
-            echo "✅ Score meets recommended threshold" >> $GITHUB_STEP_SUMMARY
+            echo "✅ Score meets the required threshold" >> $GITHUB_STEP_SUMMARY
           fi
+          exit "$PANA_EXIT"
   
   dependency-review:
     name: Dependency Review

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Run pana
         run: |
           dart pub global activate pana
-          dart pub global run pana --no-warning --exit-code-threshold 80
+          dart pub global run pana --no-warning --exit-code-threshold 130
 
       - name: Dry run publish
         run: flutter pub publish --dry-run


### PR DESCRIPTION
From the full-codebase review (Finding #6).

## Problem
The CI **Pub Score Check** ran pana but only wrote a ⚠️ summary note — it **never failed the job** (and defaulted the parsed score to `0` on a grep miss while still passing). Meanwhile `publish.yml` hard-fails the release at `pana --exit-code-threshold 80`. So a pub-score regression passes CI green and only surfaces at **release-tag time**, after the version is bumped/tagged.

## Fix
Make CI enforce the **same** threshold as the release gate, so the failure surfaces on the PR:
- CI `pana` step now runs `--exit-code-threshold 130`, captures the exit code, keeps the score summary, and fails the job (and the `CI Success` gate) when below threshold.
- `publish.yml` raised 80 → **130** so CI and release enforce the same bar.

Threshold rationale: current score is **150/160**, so 130 is a meaningful quality bar with a 20-point buffer that absorbs pana-version drift (pana is installed unpinned). Higher (140) was deferred because it would assume the separate, uncertain SPM 10-pt fix.

## Notes
- The pana "does not support Swift Package Manager" partial score (~10 pts) is tracked separately — research shows the `Package.swift` naming is already correct per Flutter's convention (hyphenated library name is required), so it is **not** a quick rename and may relate to flutter#187330.