### PR TITLE
ci: replace broken iOS simulator fallback with a clear guard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -327,19 +327,9 @@ jobs:
           else:
               print('')
           ")
-          if [ -z \"$SIMULATOR\" ]; then
-            echo \"No available iPhone simulator found, creating one...\"
-            xcrun simctl create 'iPhone 15' 'iPhone 15' || true
-            SIMULATOR=$(xcrun simctl list devices available -j | python3 -c "
-          import json, sys
-          data = json.load(sys.stdin)
-          for runtime, device_list in data['devices'].items():
-              if 'iOS' in runtime:
-                  for d in device_list:
-                      if d['isAvailable'] and 'iPhone 15' in d['name']:
-                          print(d['udid'])
-                          exit()
-            ")
+          if [ -z "$SIMULATOR" ]; then
+            echo "::error::No available iPhone simulator found on the runner."
+            exit 1
           fi
           echo "udid=$SIMULATOR" >> $GITHUB_OUTPUT
           echo "Selected simulator: $SIMULATOR"

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -1,8 +1,8 @@
 name: Integration Tests
 
 on:
-  # Disabled temporarily — re-enable tracked in #24.
-  # The simctl fallback below also needs fixing before re-enabling on PR/push.
+  # Disabled temporarily — re-enable tracked in #24 (still needs end-to-end
+  # verification of the Android emulator and iOS simulator paths on CI runners).
   # pull_request:
   #   branches: [ main, master ]
   #   paths-ignore:
@@ -131,9 +131,8 @@ jobs:
           # Get the first available iPhone simulator using Python for robust JSON parsing
           DEVICE_ID=$(xcrun simctl list devices available --json | python3 -c "import sys, json; devices = json.load(sys.stdin)['devices']; print(next((d['udid'] for runtime in devices.values() for d in runtime if 'iPhone' in d['name'] and d['isAvailable']), ''))")
           if [ -z "$DEVICE_ID" ]; then
-            echo "No iPhone simulator found, creating one..."
-            xcrun simctl create "iPhone 15" com.apple.CoreSimulator.CoreSimulatorService --type=com.apple.dt.iPhone15
-            DEVICE_ID=$(xcrun simctl list devices available --json | python3 -c "import sys, json; devices = json.load(sys.stdin)['devices']; print(next((d['udid'] for runtime in devices.values() for d in runtime if 'iPhone' in d['name'] and d['isAvailable']), ''))")
+            echo "::error::No available iPhone simulator found on the runner."
+            exit 1
           fi
           echo "Device ID: $DEVICE_ID"
           xcrun simctl boot "$DEVICE_ID" || true


### PR DESCRIPTION
From the full-codebase review (Finding #2).

## Problem
Both `ci.yml` (active iOS native-test job) and `integration_tests.yml` (dormant, #24) resolve the newest available iPhone simulator UDID, then fall back to creating one if none is found. Both fallbacks are broken:
- **`ci.yml`**: the guard `if [ -z \"$SIMULATOR\" ]` has *literal backslashes* (it's inside a `run: |` block), so the operand is the 2-char string `""` → always non-empty → the fallback **never runs**.
- **Both**: the `simctl create` invocations are **malformed** — `simctl create` is `<name> <device-type-id> [runtime]`, but the args are a name + the CoreSimulator *service* / an invalid `--type=` flag.

It's also **unnecessary** — GitHub `macos` runners always ship iPhone simulators, so the primary UDID resolution always succeeds.

## Fix
Remove the dead/malformed create-fallback in both workflows; if no simulator is found, **fail fast** with a clear `::error::` instead of continuing with an empty `-destination` (which yields a cryptic xcodebuild error). The newest-UDID resolution stays, since `xcodebuild test` requires a *concrete* simulator (a `generic/` destination is rejected for `test`).

Also refreshes the stale `integration_tests.yml` header note (the fallback is fixed; full re-enable still tracked in #24).

Low-severity (the fallback was dormant on GH runners), but removes genuinely broken code and gives a clearer failure mode.